### PR TITLE
:sparkles: Add tab bar visibility controls and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Notes:
 
 - Ensure each screen that should control the tab wires `onScroll`.
 - Use `exclude` and `currentId` on `MotionifyBottomTab` to keep the tab visible on specific routes.
+- Use `tabBar.show()` when navigating programmatically to ensure tab bar is visible.
 
 ---
 
@@ -240,8 +241,48 @@ Returns:
 - **onScroll**: Scroll handler for `ScrollView`/`FlatList`
 - **setThreshold(threshold)**
 - **setSupportIdle(enabled)**
+- **tabBar**: Tab bar visibility controls (see below)
 
 Optional config: `{ threshold?: number; supportIdle?: boolean }`
+
+#### Tab Bar Controls
+
+Use `tabBar` object from `useMotionify()` to programmatically control tab bar visibility:
+
+```tsx
+const { tabBar } = useMotionify();
+
+// Show tab bar programmatically
+tabBar.show();
+
+// Hide tab bar programmatically
+tabBar.hide();
+
+// Reset to default scroll-based behavior
+tabBar.reset();
+```
+
+**Use case**: When navigating between tabs programmatically (e.g., from a CTA button), the tab bar may remain hidden. Call `tabBar.show()` to ensure it appears:
+
+```tsx
+function HomeScreen() {
+  const { onScroll, tabBar } = useMotionify();
+  const navigation = useNavigation();
+
+  const goToRewards = () => {
+    // Show tab bar before navigating
+    tabBar.show();
+    navigation.navigate('Rewards');
+  };
+
+  return (
+    <ScrollView onScroll={onScroll} scrollEventThrottle={16}>
+      {/* content */}
+      <Button title="Go to Rewards" onPress={goToRewards} />
+    </ScrollView>
+  );
+}
+```
 
 ### Components
 
@@ -284,6 +325,54 @@ Optional config: `{ threshold?: number; supportIdle?: boolean }`
     <TabBar />
   </MotionifyBottomTab>
 </MotionifyProvider>
+```
+
+### Programmatically Show/Hide Tab Bar
+
+When user scrolls down, the tab bar hides. If you navigate to another tab programmatically (e.g., via CTA button), the tab bar may remain hidden. Use `tabBar.show()` to fix this:
+
+```tsx
+import { useNavigation } from '@react-navigation/native';
+import { useMotionify } from 'react-native-motionify';
+
+function HomeScreen() {
+  const { onScroll, tabBar } = useMotionify();
+  const navigation = useNavigation();
+
+  const goToRewards = () => {
+    // Ensure tab bar is visible before navigating
+    tabBar.show();
+    navigation.navigate('Rewards');
+  };
+
+  return (
+    <ScrollView onScroll={onScroll} scrollEventThrottle={16}>
+      <Text>Home Content</Text>
+      
+      {/* CTA Button that navigates to another tab */}
+      <Button title="View Rewards" onPress={goToRewards} />
+    </ScrollView>
+  );
+}
+
+// In your tab navigator, the tab bar stays hidden until show() is called
+function AppShell() {
+  return (
+    <MotionifyProvider>
+      <Tab.Navigator tabBar={(props) => (
+        <MotionifyBottomTab 
+          hideOn="down" 
+          translateRange={{ from: 0, to: 80 }}
+        >
+          <TabBar {...props} />
+        </MotionifyBottomTab>
+      )}>
+        <Tab.Screen name="Home" component={HomeScreen} />
+        <Tab.Screen name="Rewards" component={RewardsScreen} />
+      </Tab.Navigator>
+    </MotionifyProvider>
+  );
+}
 ```
 
 ### Parallax Header

--- a/example/src/components/BottomTabBar/index.tsx
+++ b/example/src/components/BottomTabBar/index.tsx
@@ -119,8 +119,8 @@ const MotionifyBottomTabBar = (props: MotionifyBottomTabBarProps) => {
               options.tabBarLabel !== undefined
                 ? options.tabBarLabel
                 : options.title !== undefined
-                  ? options.title
-                  : route.name;
+                ? options.title
+                : route.name;
 
             const isFocused = state.index === index;
             const isLastIndex = Number(state.routes.length - 1) === index;

--- a/src/MotionifyBottomTab.tsx
+++ b/src/MotionifyBottomTab.tsx
@@ -132,7 +132,7 @@ export const MotionifyBottomTab: React.FC<MotionifyBottomTabProps> = ({
   currentId,
   ...restProps
 }) => {
-  const { directionShared } = useMotionify({ supportIdle });
+  const { directionShared, tabBarOverride } = useMotionify({ supportIdle });
 
   // Track previous route ID to detect route changes
   const prevIdRef = useRef<string | undefined>(currentId);
@@ -157,33 +157,45 @@ export const MotionifyBottomTab: React.FC<MotionifyBottomTabProps> = ({
   /**
    * Derived value for translateY animation
    * Runs entirely on UI thread using worklets
+   * Uses Reanimated v4 .get() API for React Compiler compatibility
    */
   const translateY = useDerivedValue(() => {
     "worklet";
 
-    // Always show when route is excluded
+    // Priority 1: Programmatic override (show/hide)
+    const override = tabBarOverride.get();
+    if (override === "show") {
+      return withTiming(translateRange.from, timingConfig);
+    }
+    if (override === "hide") {
+      return withTiming(translateRange.to, timingConfig);
+    }
+
+    // Priority 2: Always show when route is excluded
     if (isExcluded) {
       return withTiming(translateRange.from, timingConfig);
     }
 
-    // Reset to visible position on route change
+    // Priority 3: Reset to visible position on route change
     if (idChanged) {
       return withTiming(translateRange.from, timingConfig);
     }
 
+    // Priority 4: Scroll direction based behavior
     // Hide when scrolling in hideOn direction
-    if (directionShared.value === hideOn) {
+    const direction = directionShared.get();
+    if (direction === hideOn) {
       return withTiming(translateRange.to, timingConfig);
     }
 
     // Show when scrolling in opposite direction
-    if (directionShared.value !== hideOn) {
+    if (direction !== hideOn) {
       return withTiming(translateRange.from, timingConfig);
     }
 
     // Default to visible
     return translateRange.from;
-  }, [hideOn, translateRange, isExcluded, idChanged, directionShared]);
+  }, [hideOn, translateRange, isExcluded, idChanged, directionShared, tabBarOverride]);
 
   const animatedStyle = useAnimatedStyle(() => {
     "worklet";

--- a/src/MotionifyProvider.tsx
+++ b/src/MotionifyProvider.tsx
@@ -24,6 +24,7 @@ import type {
   Direction,
   MotionifyContextValue,
   MotionifyConfig,
+  TabBarControls,
 } from "./types";
 
 /**
@@ -101,6 +102,7 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
   // Reanimated shared values (UI thread)
   const scrollY = useSharedValue(0);
   const directionShared = useSharedValue<Direction>("idle");
+  const tabBarOverride = useSharedValue<'show' | 'hide' | 'none'>("none");
 
   // React state (JS thread)
   const [direction, setDirection] = useState<Direction>("idle");
@@ -255,6 +257,32 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
   }, []);
 
   /**
+   * Tab bar visibility controls
+   * Programmatically control tab bar show/hide/reset
+   * Uses Reanimated v4 .set() API for React Compiler compatibility
+   */
+  const showTabBar = useCallback(() => {
+    tabBarOverride.set("show");
+  }, [tabBarOverride]);
+
+  const hideTabBar = useCallback(() => {
+    tabBarOverride.set("hide");
+  }, [tabBarOverride]);
+
+  const resetTabBar = useCallback(() => {
+    tabBarOverride.set("none");
+  }, [tabBarOverride]);
+
+  const tabBarControls: TabBarControls = useMemo(
+    () => ({
+      show: showTabBar,
+      hide: hideTabBar,
+      reset: resetTabBar,
+    }),
+    [showTabBar, hideTabBar, resetTabBar]
+  );
+
+  /**
    * Memoized context value
    */
   const contextValue = useMemo<MotionifyContextValue>(
@@ -266,6 +294,8 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
       onScroll,
       setThreshold,
       setSupportIdle,
+      tabBar: tabBarControls,
+      tabBarOverride,
     }),
     [
       scrollY,
@@ -275,6 +305,8 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
       onScroll,
       setThreshold,
       setSupportIdle,
+      tabBarControls,
+      tabBarOverride,
     ]
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export type {
   TransformStyle,
   MotionifyContextValue,
   HideOnScrollProps,
+  TabBarControls,
 } from "./types";
 
 // ============================================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,28 @@ export interface TransformStyle {
 }
 
 /**
+ * Tab bar visibility control methods
+ */
+export interface TabBarControls {
+  /**
+   * Programmatically show the tab bar
+   * Useful when navigating between tabs programmatically
+   */
+  show: () => void;
+
+  /**
+   * Programmatically hide the tab bar
+   */
+  hide: () => void;
+
+  /**
+   * Reset tab bar to its default visible state
+   * Clears any forced visibility overrides
+   */
+  reset: () => void;
+}
+
+/**
  * Internal context value shared by MotionifyProvider
  * @internal
  */
@@ -143,6 +165,18 @@ export interface MotionifyContextValue {
    * Enable/disable idle state support
    */
   setSupportIdle: (supportIdle: boolean) => void;
+
+  /**
+   * Tab bar visibility controls
+   * Use these to programmatically show/hide/reset the tab bar
+   */
+  tabBar: TabBarControls;
+
+  /**
+   * Shared value for tab bar visibility override
+   * @internal
+   */
+  tabBarOverride: SharedValue<'show' | 'hide' | 'none'>;
 }
 
 /**


### PR DESCRIPTION
Introduced programmatic controls for tab bar visibility in the Motionify library, allowing users to show, hide, or reset the tab bar. Updated README to include usage examples and instructions for the new functionality. Added package-lock.json for dependency management.