### PR TITLE
chore: add OSS health files (LICENSE, CI, tests, community docs)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,101 @@
+name: Bug report
+description: Something in react-native-motionify does not behave as documented.
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. A minimal reproduction is
+        by far the most useful thing you can give us — it usually turns a
+        multi-day guessing game into a same-day fix.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did you get instead?
+      placeholder: |
+        The bottom tab stays hidden after navigating programmatically, even though
+        `tabBar.show()` is called before `navigation.navigate(...)`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: >
+        A link to a minimal repo or an Expo Snack, or the smallest snippet that
+        reproduces the issue. Please include the `MotionifyProvider` setup and the
+        scrollable component that wires `onScroll`.
+      render: tsx
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Scroll down until the tab bar hides
+        2. Tap the CTA that navigates to another tab
+        3. The tab bar never comes back
+    validations:
+      required: true
+
+  - type: input
+    id: motionify-version
+    attributes:
+      label: react-native-motionify version
+      placeholder: 1.0.3
+    validations:
+      required: true
+
+  - type: input
+    id: reanimated-version
+    attributes:
+      label: react-native-reanimated version
+      placeholder: 3.16.1
+    validations:
+      required: true
+
+  - type: input
+    id: rn-version
+    attributes:
+      label: React Native / Expo SDK version
+      placeholder: RN 0.81.5 (Expo SDK 54)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: platforms
+    attributes:
+      label: Platforms affected
+      options:
+        - label: iOS
+        - label: Android
+        - label: Web (react-native-web)
+
+  - type: checkboxes
+    id: architecture
+    attributes:
+      label: Architecture
+      options:
+        - label: New Architecture (Fabric) enabled
+        - label: Old Architecture (Paper)
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or stack trace
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I attached `onScroll` from `useMotionify()` with `scrollEventThrottle={16}` to the scrollable component.
+          required: true
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/dennytosp/react-native-motionify/discussions
+    about: Ask how to wire Motionify into your app — please use Discussions, not issues.
+  - name: Reanimated setup problems
+    url: https://docs.swmansion.com/react-native-reanimated/docs/3.x/fundamentals/getting-started
+    about: Babel plugin, worklets, or New Architecture setup issues belong upstream.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest a new preset, prop, or component.
+labels: ["enhancement", "needs triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: >
+        Describe the UI behaviour you are building, not just the API you want.
+        Knowing the goal often reveals a simpler fix.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API
+      description: How would you like it to look in code?
+      render: tsx
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What have you tried already?
+      description: >
+        For example, driving your own `useAnimatedStyle` from `scrollY` /
+        `directionShared`, which already covers many custom cases.
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a pull request for this.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+# Summary
+
+<!-- What does this change and why? Link the issue it closes, e.g. "Closes #12". -->
+
+## Type of change
+
+- [ ] Bug fix (no API change)
+- [ ] New feature (adds a preset, prop, or component)
+- [ ] Breaking change (existing apps need to update their code)
+- [ ] Docs / internal only
+
+## How was this verified?
+
+- [ ] `bun run typecheck` passes
+- [ ] `bun test` passes
+- [ ] `bun run build` passes
+- [ ] Verified on a device or simulator (say which platform below)
+
+<!-- iOS / Android, New Architecture or Paper, Reanimated version. -->
+
+## Notes for reviewers
+
+<!-- Anything surprising: a worklet that had to stay on the UI thread, a
+     platform-specific workaround, a deliberate perf trade-off. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: npm
+    directory: /example
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(example-deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Typecheck, test & build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build
+        run: bun run build
+
+      - name: Verify published files
+        run: |
+          test -f lib/index.js
+          test -f lib/index.d.ts
+          npm pack --dry-run
+
+  package:
+    name: Pack artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: verify
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install
+      - run: bun run build
+      - run: npm pack
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: react-native-motionify-tarball
+          path: "*.tgz"
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -51,7 +51,7 @@ jobs:
     needs: verify
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -61,7 +61,7 @@ jobs:
       - run: bun run build
       - run: npm pack
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: react-native-motionify-tarball
           path: "*.tgz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write # push the version tag and create the GitHub Release
-  id-token: write # OIDC for trusted publishing and provenance
+  contents: read
 
 concurrency:
   group: release
@@ -53,9 +52,40 @@ jobs:
           VERSION="$(node -p "require('./package.json').version")"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # `npm view pkg@version` exits non-zero when that exact version is
-          # not on the registry — which is precisely the case worth publishing.
-          if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
+          # Ask the registry once for every published version.
+          #
+          # `npm view pkg@version` exits non-zero both when the version is
+          # genuinely unpublished and when the registry is unreachable, so
+          # using it directly would read a network blip as "not released yet"
+          # and try to publish. Fetch the version list instead and tell the two
+          # cases apart explicitly.
+          set +e
+          VERSIONS="$(npm view "$NAME" versions --json 2>&1)"
+          STATUS=$?
+          set -e
+
+          if [ "$STATUS" -ne 0 ]; then
+            if printf '%s' "$VERSIONS" | grep -q 'E404'; then
+              echo "$NAME has never been published. Releasing $VERSION."
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::Could not reach the npm registry for $NAME"
+            printf '%s\n' "$VERSIONS"
+            exit 1
+          fi
+
+          # A package with a single published version returns a bare string
+          # rather than an array.
+          if printf '%s' "$VERSIONS" | node -e '
+            let raw = "";
+            process.stdin.on("data", (chunk) => (raw += chunk));
+            process.stdin.on("end", () => {
+              const parsed = JSON.parse(raw);
+              const all = Array.isArray(parsed) ? parsed : [parsed];
+              process.exit(all.includes(process.argv[1]) ? 0 : 1);
+            });
+          ' "$VERSION"; then
             echo "$NAME@$VERSION is already on npm. Nothing to release."
             echo "publish=false" >> "$GITHUB_OUTPUT"
           else
@@ -69,6 +99,10 @@ jobs:
     if: needs.check.outputs.publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    permissions:
+      contents: write # push the version tag and create the GitHub Release
+      id-token: write # OIDC for trusted publishing and provenance
 
     steps:
       - uses: actions/checkout@v5
@@ -111,19 +145,33 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.check.outputs.version }}
         run: |
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
+          TAG="v$VERSION"
+
+          # npm is already published by this point, so a pre-existing tag or
+          # release is reported and stepped over rather than failing the run.
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" > /dev/null 2>&1; then
+            echo "::notice::Tag $TAG already exists on the remote. Leaving it as is."
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists. Leaving it as is."
+            exit 0
+          fi
 
           # Prefer the matching CHANGELOG section; fall back to generated notes
           # when this version has no entry.
+          NOTES="$RUNNER_TEMP/release-notes.md"
           awk -v header="## [$VERSION]" '
             index($0, header) == 1 { found = 1; next }
             found && /^## / { exit }
             found { print }
-          ' CHANGELOG.md > release-notes.md
+          ' CHANGELOG.md > "$NOTES"
 
-          if [ -s release-notes.md ] && grep -q '[^[:space:]]' release-notes.md; then
-            gh release create "v$VERSION" --title "v$VERSION" --notes-file release-notes.md
+          if grep -q '[^[:space:]]' "$NOTES"; then
+            gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
           else
-            gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+            gh release create "$TAG" --title "$TAG" --generate-notes
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
     environment: npm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,74 @@
 name: Release
 
-# Publishes to npm when a GitHub Release is published.
+# Publishes to npm when the version in package.json changes on `main`.
 #
-# One-time setup required before the first run:
-#   1. Create an npm automation token (npmjs.com -> Access Tokens -> Granular/Automation).
-#   2. Add it as the repository secret `NPM_TOKEN`
-#      (Settings -> Secrets and variables -> Actions).
+# The semver decision stays human: bump `package.json` in a pull request.
+# Merging that pull request is what releases. Everything after the merge —
+# publish, tag, GitHub Release — happens here. Pushes that do not change the
+# version are compared against the registry and skipped, so ordinary commits
+# never publish.
 #
-# The release is published with npm provenance, so consumers can verify the
-# tarball was built from this repository by this workflow.
+# Authentication uses npm trusted publishing (OIDC). There is no token to
+# store or rotate. Configure it once, at
+# https://www.npmjs.com/package/react-native-motionify/access
+# -> Trusted Publisher:
+#
+#   Organization or user:  dennytosp
+#   Repository:            react-native-motionify
+#   Workflow filename:     release.yml
+#   Environment name:      (leave blank)
+#
+# Until a trusted publisher is configured, the workflow falls back to an
+# `NPM_TOKEN` repository secret if one exists.
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+    paths: ["package.json"]
   workflow_dispatch:
 
 permissions:
-  contents: read
-  id-token: write
+  contents: write # push the version tag and create the GitHub Release
+  id-token: write # OIDC for trusted publishing and provenance
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish to npm
+  check:
+    name: Check for an unpublished version
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: npm
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      publish: ${{ steps.check.outputs.publish }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: check
+        run: |
+          NAME="$(node -p "require('./package.json').name")"
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # `npm view pkg@version` exits non-zero when that exact version is
+          # not on the registry — which is precisely the case worth publishing.
+          if npm view "$NAME@$VERSION" version > /dev/null 2>&1; then
+            echo "$NAME@$VERSION is already on npm. Nothing to release."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$NAME@$VERSION is not on npm. Releasing."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Publish v${{ needs.check.outputs.version }}
+    needs: check
+    if: needs.check.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v5
@@ -38,6 +82,11 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # Trusted publishing needs npm 11.5.1 or newer. The npm bundled with
+      # Node 22 predates it.
+      - name: Use an npm that supports trusted publishing
+        run: npm install --global npm@latest
+
       - name: Install dependencies
         run: bun install
 
@@ -50,17 +99,31 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Check release tag matches package version
-        if: github.event_name == 'release'
-        run: |
-          PKG_VERSION="$(node -p "require('./package.json').version")"
-          TAG="${GITHUB_REF_NAME#v}"
-          if [ "$PKG_VERSION" != "$TAG" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $PKG_VERSION"
-            exit 1
-          fi
-
-      - name: Publish
+      # Publishing comes before tagging on purpose: a failed publish should not
+      # leave a tag claiming a release that does not exist.
+      - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag and create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+          # Prefer the matching CHANGELOG section; fall back to generated notes
+          # when this version has no entry.
+          awk -v header="## [$VERSION]" '
+            index($0, header) == 1 { found = 1; next }
+            found && /^## / { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+          if [ -s release-notes.md ] && grep -q '[^[:space:]]' release-notes.md; then
+            gh release create "v$VERSION" --title "v$VERSION" --notes-file release-notes.md
+          else
+            gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+# Publishes to npm when a GitHub Release is published.
+#
+# One-time setup required before the first run:
+#   1. Create an npm automation token (npmjs.com -> Access Tokens -> Granular/Automation).
+#   2. Add it as the repository secret `NPM_TOKEN`
+#      (Settings -> Secrets and variables -> Actions).
+#
+# The release is published with npm provenance, so consumers can verify the
+# tarball was built from this repository by this workflow.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build
+        run: bun run build
+
+      - name: Check release tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,4 @@ node_modules/
 dist/
 test/
 docs/
-CHANGELOG.md
 *.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Continuous integration: typecheck, unit tests, build, and package verification
   on every push and pull request.
 - Unit tests for the pure helpers in `src/utils.ts`.
-- Release workflow that publishes to npm with provenance from a GitHub Release.
+- Release workflow: bumping the version in `package.json` and merging to `main`
+  publishes to npm with provenance, pushes the `v<version>` tag, and opens a
+  GitHub Release from this file. Pushes that do not change the version are
+  skipped.
 - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and pull request
   templates, and Dependabot configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- MIT `LICENSE` file (the package was already declared MIT in `package.json`).
+- Continuous integration: typecheck, unit tests, build, and package verification
+  on every push and pull request.
+- Unit tests for the pure helpers in `src/utils.ts`.
+- Release workflow that publishes to npm with provenance from a GitHub Release.
+- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and pull request
+  templates, and Dependabot configuration.
+
+## [1.0.3] - 2026-02-27
+
+### Changed
+
+- `release` script for publishing, and `prepack` now builds through Bun.
+
+## [1.0.2] - 2026-02-27
+
+### Added
+
+- Programmatic tab bar visibility controls via `tabBar.show()`, `tabBar.hide()`,
+  and `tabBar.reset()` from `useMotionify()`, for cases where navigating
+  programmatically would otherwise leave the tab bar hidden.
+
+## [1.0.1] - 2025-10-31
+
+### Fixed
+
+- Crash caused by an invalid `Extrapolation` value passed to Reanimated.
+
+### Added
+
+- Demo video and expanded examples in the README.
+
+## [1.0.0] - 2025-10-31
+
+### Added
+
+- Initial release: `MotionifyProvider`, `useMotionify`, `MotionifyView`,
+  `MotionifyViewWithInterpolation`, `MotionifyBottomTab`,
+  `MotionifyBottomTabWithInterpolation`, plus translation and interpolation
+  presets and helper utilities.
+
+[unreleased]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/dennytosp/react-native-motionify/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the `react-native-reanimated` peer range to `>=3.16.0`. The tab bar
+  controls (`tabBar.show()` / `hide()` / `reset()`) call `SharedValue.set()`,
+  which was added in Reanimated 3.16 — on 3.0 through 3.15 the declared range
+  allowed an install that then threw `tabBarOverride.set is not a function` at
+  runtime.
+- The `LegendList` example in the README imported from `legendapp-ui`, which
+  does not exist on npm. The package is `@legendapp/list`.
+
+### Changed
+
+- Removed the deprecated `@types/react-native` devDependency (React Native has
+  shipped its own types since 0.71) and added `react`, `react-native`, and
+  `react-native-reanimated` as explicit devDependencies so type checking no
+  longer depends on the package manager auto-installing peers.
+
 ### Added
 
 - MIT `LICENSE` file (the package was already declared MIT in `package.json`).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,125 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**phong.dinh2108@gmail.com**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. Violating
+these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. Violating these
+terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,15 +99,30 @@ When contributing to animated code paths:
 
 ## Releasing
 
-Maintainers only.
+Maintainers only. Merging a version bump into `main` is what releases —
+there is no separate publish step to remember.
 
-1. Update `CHANGELOG.md`, moving `Unreleased` entries under the new version.
-2. Bump the version in `package.json`.
-3. Merge to `main` and confirm CI is green.
-4. Create a GitHub Release with the tag `v<version>` (e.g. `v1.1.0`).
-5. The [Release workflow](./.github/workflows/release.yml) verifies the tag
-   matches `package.json`, re-runs the checks, and publishes to npm with
-   provenance.
+1. In a pull request: move the `Unreleased` entries in `CHANGELOG.md` under the
+   new version, and bump `package.json`.
+
+   ```bash
+   npm version minor --no-git-tag-version   # or patch / major
+   ```
+
+   `--no-git-tag-version` matters: the tag is created by CI after a successful
+   publish, so it never points at a release that failed halfway.
+
+2. Merge the pull request.
+
+The [Release workflow](./.github/workflows/release.yml) then compares
+`package.json` against the registry. If that version is already on npm it stops;
+otherwise it re-runs typecheck, tests and build, publishes with provenance,
+pushes the `v<version>` tag, and opens a GitHub Release using the matching
+`CHANGELOG.md` section.
+
+Choosing the version number stays a human decision — nothing infers semver from
+commit messages. Note that anything exported from `src/index.ts` is public API
+(see above), so removals and renames need a major bump.
 
 ## Questions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to react-native-motionify
+
+Thanks for your interest in improving Motionify. This document covers how to get
+the library running locally, what the checks are, and how releases work.
+
+By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Ways to help
+
+- **Report a bug** — use the [bug report template](https://github.com/dennytosp/react-native-motionify/issues/new?template=bug_report.yml).
+  A minimal reproduction matters more than a long description.
+- **Improve the docs** — if a prop, preset, or setup step confused you, it will
+  confuse the next person. Doc PRs are always welcome.
+- **Add a preset** — `TRANSLATION_PRESETS` and `INTERPOLATION_PRESETS` are the
+  cheapest place to contribute something useful.
+- **Fix a bug** — check the issue is not already assigned, then open a PR.
+
+## Prerequisites
+
+- [Bun](https://bun.sh) 1.1 or newer (the library's scripts run on Bun)
+- Node.js 20 or newer (used by `npm pack` / publishing)
+- For the example app: Xcode (iOS) and/or Android Studio, plus the
+  [Reanimated 3 setup](https://docs.swmansion.com/react-native-reanimated/docs/3.x/fundamentals/getting-started)
+
+## Local setup
+
+```bash
+git clone https://github.com/dennytosp/react-native-motionify.git
+cd react-native-motionify
+bun install
+```
+
+## The checks
+
+These are exactly what CI runs on every pull request, so run them before pushing:
+
+```bash
+bun run typecheck   # tsc --noEmit over src/ and test/
+bun test            # unit tests for the pure helpers in src/utils.ts
+bun run build       # tsc -> lib/
+```
+
+`bun run dev` runs the compiler in watch mode while you work.
+
+### About the tests
+
+`src/utils.ts` is pure and therefore directly testable — clamping, lerping,
+range mapping, and the interpolation-config builders all have coverage in
+`test/utils.test.ts`. Because `react-native-reanimated` cannot be evaluated
+outside a native runtime, `test/setup.ts` stubs the one thing the helpers need
+from it (the `Extrapolation` enum).
+
+The components in `MotionifyProvider`, `MotionifyView`, and
+`MotionifyBottomTab` drive Reanimated worklets on the UI thread, so they are
+verified on a device or simulator through the example app rather than in Jest.
+If you change one, say which platform you tested on in your PR.
+
+## Running the example app
+
+The `example/` folder is an Expo app that consumes the library.
+
+```bash
+cd example
+bun install
+bun run ios       # or: bun run android
+```
+
+To test your local changes rather than the published package, point the example
+at the repository root (`bun add ../` or a workspace link) and rebuild.
+
+## Pull requests
+
+1. Branch off `main`. Use a descriptive branch name, e.g. `fix/tab-bar-stuck-hidden`.
+2. Keep the change focused — one logical change per PR reviews far faster.
+3. Run the three checks above.
+4. Fill in the PR template, including which platform you verified on.
+5. If you change public API, update the README and add an entry to
+   [CHANGELOG.md](./CHANGELOG.md) under `Unreleased`.
+
+Commit messages in this repo use a gitmoji + short summary style
+(`:sparkles: Add tab bar visibility controls`), but this is not enforced —
+a clear message is what matters.
+
+## Public API changes
+
+Anything exported from `src/index.ts` is public API. Removing or renaming an
+export, or changing a prop's meaning, is a breaking change and needs a major
+version bump. Prefer adding an optional prop with a backwards-compatible default.
+
+## Performance expectations
+
+Motionify's reason to exist is that scroll animations stay on the UI thread.
+When contributing to animated code paths:
+
+- Keep worklets small; precompute anything heavy outside the worklet.
+- Do not introduce `runOnJS` in a per-frame path.
+- Do not add runtime dependencies. Reanimated, React, and React Native stay
+  peer dependencies — the library ships with none of its own.
+
+## Releasing
+
+Maintainers only.
+
+1. Update `CHANGELOG.md`, moving `Unreleased` entries under the new version.
+2. Bump the version in `package.json`.
+3. Merge to `main` and confirm CI is green.
+4. Create a GitHub Release with the tag `v<version>` (e.g. `v1.1.0`).
+5. The [Release workflow](./.github/workflows/release.yml) verifies the tag
+   matches `package.json`, re-runs the checks, and publishes to npm with
+   provenance.
+
+## Questions
+
+Open a [Discussion](https://github.com/dennytosp/react-native-motionify/discussions)
+for usage questions, and an issue for bugs.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Phong Dinh (dennytosp)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 ## React Native Motionify
 
+[![CI](https://github.com/dennytosp/react-native-motionify/actions/workflows/ci.yml/badge.svg)](https://github.com/dennytosp/react-native-motionify/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/react-native-motionify.svg)](https://www.npmjs.com/package/react-native-motionify)
+[![npm downloads](https://img.shields.io/npm/dm/react-native-motionify.svg)](https://www.npmjs.com/package/react-native-motionify)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![TypeScript](https://img.shields.io/badge/types-included-blue.svg)](./src/types.ts)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
+
 A lightweight, production-ready toolkit for smooth, scroll-driven UI with Reanimated 3.
 
 - **UI-thread animations** at 60 FPS
@@ -469,14 +476,34 @@ Notes:
 
 ## Contributing
 
-To contribute to this library:
+Contributions are welcome — bug reports, docs fixes, and new presets especially.
 
-1. Make changes to the implementation in `react-native-motionify`.
-2. Test with various build configurations.
-3. Submit pull requests with clear descriptions of changes and benefits.
+```bash
+git clone https://github.com/dennytosp/react-native-motionify.git
+cd react-native-motionify
+bun install
+
+bun run typecheck   # tsc --noEmit over src/ and test/
+bun test            # unit tests for the pure helpers
+bun run build       # tsc -> lib/
+```
+
+These three commands are exactly what CI runs on every pull request. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for the full guide, and
+[CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) for community expectations.
+
+- Found a bug? [Open an issue](https://github.com/dennytosp/react-native-motionify/issues/new?template=bug_report.yml)
+- Have a usage question? [Start a discussion](https://github.com/dennytosp/react-native-motionify/discussions)
+- Found a security problem? See [SECURITY.md](./SECURITY.md) — please do not open a public issue
+
+---
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md).
 
 ---
 
 ## License
 
-MIT
+[MIT](./LICENSE) © Phong Dinh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ https://github.com/user-attachments/assets/133b5ddf-9a9a-48a1-9697-ab40de0534a1
 
 ---
 
+## Requirements
+
+| Package                   | Minimum  |
+| ------------------------- | -------- |
+| `react`                   | 16.8     |
+| `react-native`            | 0.60     |
+| `react-native-reanimated` | **3.16** |
+
+Reanimated 3.16 is the floor because the tab bar controls use
+`SharedValue.set()`, which was introduced in that release. Reanimated 4 is
+supported.
+
+---
+
 ## Installation
 
 ```bash
@@ -37,7 +51,7 @@ pnpm add react-native-motionify
 bun add react-native-motionify
 
 # peer deps
-npm install react-native-reanimated@^3.0.0
+npm install react-native-reanimated@">=3.16"
 ```
 
 Follow Reanimated 3 setup: `https://docs.swmansion.com/react-native-reanimated/docs/3.x/fundamentals/getting-started`.
@@ -128,7 +142,7 @@ const { onScroll } = useMotionify();
 
 ```tsx
 // LegendList example
-import { LegendList } from "legendapp-ui";
+import { LegendList } from "@legendapp/list";
 const { onScroll } = useMotionify();
 
 <LegendList

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes land on the latest published minor release. Older versions are
+not patched — please upgrade before reporting.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.0.x   | Yes       |
+| < 1.0   | No        |
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for a security problem.
+
+Report it privately through GitHub's
+[private vulnerability reporting](https://github.com/dennytosp/react-native-motionify/security/advisories/new),
+or by email to **phong.dinh2108@gmail.com**.
+
+Please include:
+
+- The affected version of `react-native-motionify`
+- A description of the issue and its impact
+- Steps to reproduce, ideally with a minimal snippet
+
+### What to expect
+
+- **Acknowledgement** within 5 working days.
+- An assessment and a plan (fix, mitigation, or "not a vulnerability, and why")
+  within 14 days.
+- Credit in the release notes when the fix ships, unless you prefer otherwise.
+
+## Scope
+
+`react-native-motionify` is a UI animation library. It ships no runtime
+dependencies, performs no network or filesystem access, and does not handle
+credentials or user data. Realistic reports in scope include supply-chain issues
+with the published npm package (tampered tarball, compromised release workflow)
+and code paths that could be abused to crash or hang an app.
+
+Vulnerabilities in `react-native-reanimated`, React Native, or Expo should be
+reported to those projects directly.

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test/setup.ts"]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
+    "test": "bun test",
     "prepack": "bun run build",
     "release": "node scripts/publish.js"
   },
@@ -37,6 +38,7 @@
     "react-native-reanimated": ">=3.0.0"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "@types/react": "^18.0.0",
     "@types/react-native": "^0.72.0",
     "typescript": "^5.0.0"
@@ -44,6 +46,15 @@
   "files": [
     "lib",
     "src",
-    "README.md"
-  ]
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-native": ">=0.60.0",
-    "react-native-reanimated": ">=3.0.0"
+    "react-native-reanimated": ">=3.16.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "@types/react": "^18.0.0",
-    "@types/react-native": "^0.72.0",
+    "react": "^19.1.0",
+    "react-native": "^0.81.5",
+    "react-native-reanimated": "^4.1.3",
     "typescript": "^5.0.0"
   },
   "files": [

--- a/src/MotionifyProvider.tsx
+++ b/src/MotionifyProvider.tsx
@@ -266,7 +266,9 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
   /**
    * Tab bar visibility controls
    * Programmatically control tab bar show/hide/reset
-   * Uses Reanimated v4 .set() API for React Compiler compatibility
+   *
+   * Uses SharedValue.set() for React Compiler compatibility. That method was
+   * added in Reanimated 3.16, which is why it is the minimum peer version.
    */
   const showTabBar = useCallback(() => {
     tabBarOverride.set("show");

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,10 @@
  * - Fabric/New Architecture compatible
  * - Zero dependencies (except peer deps)
  *
+ * Requires react-native-reanimated 3.16 or newer.
+ *
  * @packageDocumentation
- * @version 2.0.0
- * @author React Native Motionify Scroll Team
+ * @author Phong Dinh (dennytosp)
  */
 
 // ============================================================================

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,15 @@
+import { mock } from "bun:test";
+
+/**
+ * `react-native-reanimated` pulls in the React Native runtime, which cannot be
+ * evaluated outside a native/Metro environment. The pure helpers in `src/utils`
+ * only need the `Extrapolation` enum, so we stub it with the same string values
+ * Reanimated 3 uses.
+ */
+mock.module("react-native-reanimated", () => ({
+  Extrapolation: {
+    CLAMP: "clamp",
+    EXTEND: "extend",
+    IDENTITY: "identity",
+  },
+}));

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "bun:test";
+import { Extrapolation } from "react-native-reanimated";
+
+import {
+  DEFAULTS,
+  INTERPOLATION_PRESETS,
+  TRANSLATION_PRESETS,
+  clamp,
+  createFadeInterpolation,
+  createInterpolation,
+  createParallaxInterpolation,
+  createRotationInterpolation,
+  createScaleInterpolation,
+  createTranslationRange,
+  getExtrapolationMode,
+  lerp,
+  mapRange,
+} from "../src/utils";
+
+describe("clamp", () => {
+  it("returns the value when it is inside the range", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+
+  it("clamps to the bounds", () => {
+    expect(clamp(-3, 0, 10)).toBe(0);
+    expect(clamp(42, 0, 10)).toBe(10);
+  });
+
+  it("keeps the bounds themselves untouched", () => {
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+});
+
+describe("lerp", () => {
+  it("returns the endpoints at progress 0 and 1", () => {
+    expect(lerp(0, 100, 0)).toBe(0);
+    expect(lerp(0, 100, 1)).toBe(100);
+  });
+
+  it("interpolates linearly in between", () => {
+    expect(lerp(0, 100, 0.25)).toBe(25);
+    expect(lerp(-50, 50, 0.5)).toBe(0);
+  });
+
+  it("extrapolates past the endpoints", () => {
+    expect(lerp(0, 100, 1.5)).toBe(150);
+    expect(lerp(0, 100, -0.5)).toBe(-50);
+  });
+});
+
+describe("mapRange", () => {
+  it("maps a value from one range to another", () => {
+    expect(mapRange(50, 0, 100, 0, 1)).toBe(0.5);
+    expect(mapRange(0, 0, 200, 0, -100)).toBe(0);
+    expect(mapRange(200, 0, 200, 0, -100)).toBe(-100);
+  });
+
+  it("supports inverted output ranges", () => {
+    expect(mapRange(25, 0, 100, 1, 0)).toBe(0.75);
+  });
+});
+
+describe("getExtrapolationMode", () => {
+  it("defaults to clamp", () => {
+    expect(getExtrapolationMode()).toBe(Extrapolation.CLAMP);
+  });
+
+  it("passes an explicit mode through", () => {
+    expect(getExtrapolationMode(Extrapolation.EXTEND)).toBe(Extrapolation.EXTEND);
+  });
+});
+
+describe("createTranslationRange", () => {
+  it("builds a {from, to} pair", () => {
+    expect(createTranslationRange(0, 80)).toEqual({ from: 0, to: 80 });
+  });
+});
+
+describe("createInterpolation", () => {
+  it("builds a config with the default extrapolation", () => {
+    expect(createInterpolation([0, 100], [1, 0])).toEqual({
+      inputRange: [0, 100],
+      outputRange: [1, 0],
+      extrapolate: Extrapolation.CLAMP,
+    });
+  });
+
+  it("accepts string output ranges (e.g. rotations)", () => {
+    expect(createInterpolation([0, 1], ["0deg", "180deg"], Extrapolation.EXTEND)).toEqual({
+      inputRange: [0, 1],
+      outputRange: ["0deg", "180deg"],
+      extrapolate: Extrapolation.EXTEND,
+    });
+  });
+});
+
+describe("createFadeInterpolation", () => {
+  it("fades out by default", () => {
+    expect(createFadeInterpolation(200)).toEqual({
+      inputRange: [0, 100, 200],
+      outputRange: [1, 0.5, 0],
+      extrapolate: Extrapolation.CLAMP,
+    });
+  });
+
+  it("fades in when asked", () => {
+    expect(createFadeInterpolation(200, true).outputRange).toEqual([0, 0.5, 1]);
+  });
+});
+
+describe("createScaleInterpolation", () => {
+  it("scales from 1 to 0.8 by default", () => {
+    expect(createScaleInterpolation(200)).toEqual({
+      inputRange: [0, 200],
+      outputRange: [1, 0.8],
+      extrapolate: Extrapolation.CLAMP,
+    });
+  });
+
+  it("honours custom scales", () => {
+    expect(createScaleInterpolation(100, 0.5, 2).outputRange).toEqual([0.5, 2]);
+  });
+});
+
+describe("createParallaxInterpolation", () => {
+  it("moves at half speed by default and extends past the range", () => {
+    expect(createParallaxInterpolation(200)).toEqual({
+      inputRange: [0, 200],
+      outputRange: [0, -100],
+      extrapolate: Extrapolation.EXTEND,
+    });
+  });
+
+  it("scales the offset by the parallax factor", () => {
+    expect(createParallaxInterpolation(200, 2).outputRange).toEqual([0, -400]);
+  });
+});
+
+describe("createRotationInterpolation", () => {
+  it("rotates a full turn by default", () => {
+    expect(createRotationInterpolation(360)).toEqual({
+      inputRange: [0, 360],
+      outputRange: [0, 360],
+      extrapolate: Extrapolation.CLAMP,
+    });
+  });
+
+  it("honours a custom rotation", () => {
+    expect(createRotationInterpolation(100, 90).outputRange).toEqual([0, 90]);
+  });
+});
+
+describe("constants", () => {
+  it("exposes the documented defaults", () => {
+    expect(DEFAULTS.THRESHOLD).toBe(8);
+    expect(DEFAULTS.SCROLL_EVENT_THROTTLE).toBe(16);
+    expect(DEFAULTS.SUPPORT_IDLE).toBe(false);
+  });
+
+  it("ships translation presets shaped like {from, to}", () => {
+    for (const preset of Object.values(TRANSLATION_PRESETS)) {
+      expect(typeof preset.from).toBe("number");
+      expect(typeof preset.to).toBe("number");
+    }
+  });
+
+  it("ships interpolation presets with matching range lengths", () => {
+    for (const preset of Object.values(INTERPOLATION_PRESETS)) {
+      expect(preset.inputRange.length).toBe(preset.outputRange.length);
+      expect(preset.inputRange.length).toBeGreaterThan(1);
+    }
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "lib", "example"]
+}


### PR DESCRIPTION
## Why

The repo was missing the basics that both consumers and program reviewers look for:

- `package.json` declared MIT, but there was **no `LICENSE` file** — GitHub and npm both showed the project as unlicensed, which technically means "all rights reserved" to anyone reading it.
- **No CI.** `npm test` was `echo "Error: no test specified" && exit 1`, so nothing verified a PR.
- No contributing guide, code of conduct, security policy, changelog, or issue templates.

Auditing the dependencies while wiring up CI also turned up a correctness bug — see the last section.

## What changed

**Licensing**
- `LICENSE` — MIT, matching the existing `package.json` declaration.

**CI** (`.github/workflows/ci.yml`)
- Runs on every push to `main` and every PR: `typecheck` → `bun test` → `build` → verifies `lib/index.js` + `lib/index.d.ts` exist and `npm pack` succeeds.
- Second job uploads the packed tarball as an artifact so a PR can be installed and tried before merge.

**Tests** — 24 unit tests covering the pure helpers in `src/utils.ts`: `clamp`, `lerp`, `mapRange`, `getExtrapolationMode`, all five interpolation builders, and shape invariants over `DEFAULTS` / `TRANSLATION_PRESETS` / `INTERPOLATION_PRESETS`.

`react-native-reanimated` can't be evaluated outside a native runtime, so `test/setup.ts` stubs the `Extrapolation` enum — the only thing those helpers touch.

The worklet-driven components stay verified on device via `example/`, and `CONTRIBUTING.md` says so explicitly rather than pretending they're covered.

**Type safety** — new `typecheck` script and `tsconfig.test.json` so `src/` *and* `test/` are both type-checked (`tsconfig.json` stays the emit config with `rootDir: src`).

**Releases** (`.github/workflows/release.yml`) — merging a version bump into `main` is what publishes. The workflow compares `package.json` against the registry and stops if that version already exists, so ordinary commits never publish and the semver decision stays a human one made in the PR. After a successful publish it pushes the `v<version>` tag and opens a GitHub Release from the matching `CHANGELOG.md` section — that order means a tag can never point at a release that failed halfway.

Authentication is npm **trusted publishing** (OIDC): no token stored in the repository, nothing to rotate, and provenance is attested automatically. An `NPM_TOKEN` secret is still honoured as a fallback.

The "is this version already published?" check is deliberately not `npm view pkg@version` — that exits non-zero both when the version is unpublished *and* when the registry is unreachable, so a network blip would read as "not released yet" and trigger a publish. It fetches the version list once and separates the two: a 404 on the package name means never published and proceeds, anything else fails the run. `contents: write` and `id-token: write` are scoped to the publishing job only.

The existing local `bun run release` flow still works unchanged (`publishConfig` deliberately does *not* set `provenance: true`, which would break local publishes).

**Community docs** — `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `SECURITY.md`, `CHANGELOG.md` (backfilled from git history), bug/feature issue forms, PR template, Dependabot for npm + example + Actions.

**Packaging** — `LICENSE` and `CHANGELOG.md` now ship in the tarball; added `engines`, `sideEffects: false`, `publishConfig.access`.

**README** — CI/npm/license badges, a Requirements table, and a contributing section with the actual commands.

## Bug fixes found during the dependency audit

**Peer range allowed installs that crash at runtime.** `tabBar.show()` / `hide()` / `reset()` call `SharedValue.set()`. That method landed in Reanimated **3.16.0** — verified by unpacking the 3.10, 3.15 and 3.16 tarballs and diffing the `SharedValue` interface. The declared peer range was `>=3.0.0`, so installing against 3.0–3.15 was accepted by the package manager and then threw `tabBarOverride.set is not a function` the first time a consumer touched the tab bar controls. Peer range is now `>=3.16.0`, documented in a Requirements table.

**A README snippet that cannot be installed.** The `LegendList` example imported from `legendapp-ui`, which returns 404 on npm. The package is `@legendapp/list`.

**Deprecated types dependency.** `@types/react-native` has been a stub since React Native started shipping its own types in 0.71 (npm's own deprecation notice says so). Removed, and `react`, `react-native`, `react-native-reanimated` are now explicit devDependencies — type checking previously depended on the package manager auto-installing peer dependencies.

**Stale docblock.** `src/index.ts` claimed `@version 2.0.0` (the package is 1.0.3) and credited a team that does not exist.

## Testing

Run locally after a clean reinstall following the dependency changes:

```
bun run typecheck   # clean
bun test            # 24 pass, 0 fail
bun run build       # clean
npm pack --dry-run  # 22 files, includes LICENSE + CHANGELOG
```

CI is green on this branch.

The release workflow's version check was exercised against the live registry across every branch it has:

| Input | Result |
| --- | --- |
| `react-native-motionify@1.0.3` | already published, skip |
| `react-native-motionify@1.1.0` | not published, release |
| package that has never been published | release |
| package with a single version (registry returns a bare string, not an array) | handled |
| registry unreachable | hard fail, no publish |

The CHANGELOG note extraction was tested too, including that `1.0.1` does not swallow a hypothetical `1.0.10` section, and that a version with no CHANGELOG entry falls back to generated notes.

Not covered: the publishing job itself has never run — verifying it end to end would mean publishing. Its first real execution is the first version bump merged after this. The Reanimated worklet components are not exercised by automated tests, and the `>=3.16.0` floor was verified by inspecting Reanimated's published type definitions rather than by running the library against 3.15. Neither repo commits a lockfile, so CI resolves dependencies fresh on every run and is not reproducible.

## Risk

The peer range change is the only one that affects consumers. Tightening it cannot break a working install — it can only reject an install that would have crashed. It does mean anyone pinned below Reanimated 3.16 will now see a peer warning, which is the intent.

Version bump: this is a behaviour-relevant metadata fix, so a minor bump rather than a patch is appropriate when releasing.

## What happens when this merges

Two workflows fire on the merge commit:

- **CI** runs as usual.
- **Release** runs too, because this PR touches `package.json`. Its `check` job should find `1.0.3` already on npm and skip the publishing job. That is the intended outcome and doubles as the first live test of the check logic. If the publishing job does *not* skip, something is wrong — stop and look before it reaches npm.

## Follow-up needed from the maintainer

**Configure the trusted publisher on npm** — this is the only step, and it is on npmjs.com rather than here: [package access settings](https://www.npmjs.com/package/react-native-motionify/access) → Trusted Publisher →

| Field | Value |
| --- | --- |
| Organization or user | `dennytosp` |
| Repository | `react-native-motionify` |
| Workflow filename | `release.yml` |
| Environment name | *(leave blank)* |

There is no secret to create. Until it is configured, keep releasing with `bun run release` — nothing breaks.

Tags `v1.0.0`–`v1.0.3` and matching GitHub Releases have already been backfilled onto the published commits, so the CHANGELOG compare links resolve.

Two behavioural bugs found during review are filed separately rather than fixed here, since they change runtime behaviour for existing users: #4 and #5.
