### PR TITLE
fix: apply scroll threshold to down direction too

### DIFF
--- a/src/MotionifyProvider.tsx
+++ b/src/MotionifyProvider.tsx
@@ -216,7 +216,7 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
       const totalDelta = clampedY - scrollStartYRef.current;
       let newDirection: Direction | null = null;
 
-      if (totalDelta > 0) {
+      if (totalDelta > thresholdRef.current) {
         newDirection = "down";
       } else if (totalDelta < -thresholdRef.current) {
         newDirection = "up";


### PR DESCRIPTION
## Summary
- Require `threshold` pixels before switching to `down`, matching the existing `up` gate.

Closes #4