### PR TITLE
:construction_worker: Choose the release version with pull request labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,47 @@
 version: 2
 
+# Every Dependabot pull request carries `release:skip`. Merging one publishes
+# nothing on its own — dependency bumps here are development-only and do not
+# change the shipped library. Remove the label from a pull request that should
+# go out as a release.
+
 updates:
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels: ["dependencies", "release:skip"]
     commit-message:
       prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: development
+        # TypeScript majors remove compiler options outright, so they need a
+        # tsconfig migration rather than a routine merge. Keeping them out of
+        # the group means one red pull request instead of a red group that
+        # blocks four green bumps.
+        exclude-patterns: ["typescript"]
 
   - package-ecosystem: npm
     directory: /example
     schedule:
       interval: monthly
     open-pull-requests-limit: 3
+    labels: ["dependencies", "release:skip"]
     commit-message:
       prefix: "chore(example-deps)"
+    groups:
+      example:
+        patterns: ["*"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    labels: ["dependencies", "release:skip"]
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
 
-# Every Dependabot pull request carries `release:skip`. Merging one publishes
-# nothing on its own — dependency bumps here are development-only and do not
-# change the shipped library. Remove the label from a pull request that should
-# go out as a release.
+# Two pull requests per ecosystem at most, not one per dependency.
+#
+# Minor and patch updates travel together: they are routine, they either all
+# pass CI or the group tells you which one broke. Majors travel in a separate
+# group because that is where breaking changes live — TypeScript 7 removing
+# `moduleResolution=node10` should not be able to hold four harmless bumps
+# hostage in the same pull request.
+#
+# Every Dependabot pull request carries `release:skip`, so merging one never
+# publishes on its own. Remove the label from a pull request that should go
+# out as a release.
 
 updates:
   - package-ecosystem: npm
@@ -15,13 +22,12 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
-      dev-dependencies:
-        dependency-type: development
-        # TypeScript majors remove compiler options outright, so they need a
-        # tsconfig migration rather than a routine merge. Keeping them out of
-        # the group means one red pull request instead of a red group that
-        # blocks four green bumps.
-        exclude-patterns: ["typescript"]
+      dependencies:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      major-updates:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: npm
     directory: /example
@@ -34,6 +40,10 @@ updates:
     groups:
       example:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      example-major:
+        patterns: ["*"]
+        update-types: ["major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -66,6 +66,24 @@ jobs:
       - name: Fetch main
         run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
 
+      # Drop the previous run's bump before recomputing. Without this,
+      # relabelling stacks a second bump commit on top of the first and leaves
+      # the CHANGELOG heading naming the version that is no longer being
+      # released. Only ever unwinds this workflow's own commit — a human push
+      # on top makes HEAD something else, and nothing is touched.
+      - name: Unwind the previous bump
+        id: unwind
+        run: |
+          if [ "$(git log -1 --format=%an)" = "github-actions[bot]" ]; then
+            case "$(git log -1 --format=%s)" in
+              ":bookmark: Bump version to "*)
+                echo "Dropping $(git log -1 --format=%s) to recompute from scratch."
+                git reset --hard HEAD~1
+                echo "unwound=true" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          fi
+
       - name: Work out the target version
         id: target
         env:
@@ -118,16 +136,25 @@ jobs:
         env:
           TARGET: ${{ steps.target.outputs.target }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
+          UNWOUND: ${{ steps.unwind.outputs.unwound }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add package.json CHANGELOG.md
 
+          # Nothing staged means the recomputed result matches what is already
+          # on the branch, so the remote is left exactly as it is — including
+          # in the unwound case, where the commit that was dropped locally was
+          # already correct.
           if git diff --cached --quiet; then
             echo "Already set to $TARGET. Nothing to commit."
             exit 0
           fi
 
           git commit -m ":bookmark: Bump version to $TARGET"
-          git push origin "HEAD:$BRANCH"
+
+          # `--force-with-lease` only because the previous bump was unwound.
+          # It refuses if anyone pushed since this job fetched, so a
+          # contributor's work cannot be overwritten.
+          git push --force-with-lease origin "HEAD:$BRANCH"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,133 @@
+name: Bump version
+
+# Writes the version a pull request will release into the pull request itself,
+# so the number is visible — and editable — before anyone merges.
+#
+#   release:skip    no bump; merging publishes nothing
+#   release:major   next major after the version on `main`
+#   release:minor   next minor
+#   (no label)      next patch
+#
+# The target is always computed from `main`, never from the pull request's own
+# package.json, so re-running this cannot make the version climb: label a pull
+# request minor, then major, then minor again, and it lands on the same number
+# it would have had the first time.
+#
+# The bump lives here rather than in the release workflow because `main`
+# requires a pull request, and the Actions bot cannot push to it. Merging the
+# pull request is what carries the bump commit onto `main`, through the front
+# door.
+#
+# Note: pushes made with GITHUB_TOKEN do not start new workflow runs, so CI
+# does not re-run on the bump commit. That commit only rewrites the version
+# field and moves a CHANGELOG heading — the code CI already verified is
+# byte-for-byte the same.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    name: Set the release version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # A fork's branch cannot be pushed to with GITHUB_TOKEN. Those pull
+    # requests get their version set by a maintainer after the merge, or by
+    # relabelling once the branch is in this repository.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'release:skip')
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      # Every comparison below is against `main`. Fetch it explicitly rather
+      # than relying on checkout having left a usable remote-tracking ref.
+      - name: Fetch main
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Work out the target version
+        id: target
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: |
+          case " $LABELS " in
+            *" release:major "*) BUMP=major ;;
+            *" release:minor "*) BUMP=minor ;;
+            *) BUMP=patch ;;
+          esac
+
+          BASE="$(git show origin/main:package.json \
+            | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")"
+
+          # Compute the target with npm's own semver rather than string
+          # arithmetic: reset to what `main` carries, then bump once.
+          npm pkg set "version=$BASE" > /dev/null
+          npm version "$BUMP" --no-git-tag-version --allow-same-version > /dev/null
+
+          TARGET="$(node -p "require('./package.json').version")"
+          echo "Labels: ${LABELS:-<none>} -> $BUMP. $BASE -> $TARGET."
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Promote the CHANGELOG entry
+        env:
+          TARGET: ${{ steps.target.outputs.target }}
+        run: |
+          # Any `## [x.y.z]` heading that this branch has and `main` does not is
+          # one this workflow wrote earlier. If it names a different version —
+          # because the release label changed after the fact — say so loudly
+          # rather than silently leaving the CHANGELOG describing the wrong
+          # release.
+          ADDED="$(comm -13 \
+            <(git show origin/main:CHANGELOG.md | grep -o '^## \[[^]]*\]' | sort -u) \
+            <(grep -o '^## \[[^]]*\]' CHANGELOG.md | sort -u))"
+
+          if [ -n "$ADDED" ] && [ "$ADDED" != "## [$TARGET]" ]; then
+            echo "::warning::CHANGELOG.md has a section for $ADDED but this pull request now releases $TARGET. Rename that heading by hand."
+            exit 0
+          fi
+
+          if [ -n "$ADDED" ]; then
+            echo "CHANGELOG.md already has a section for $TARGET."
+            exit 0
+          fi
+
+          echo "CHANGELOG: $(node scripts/release-changelog.mjs "$TARGET" "$(date -u +%Y-%m-%d)")"
+
+      - name: Commit the bump
+        env:
+          TARGET: ${{ steps.target.outputs.target }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add package.json CHANGELOG.md
+
+          if git diff --cached --quiet; then
+            echo "Already set to $TARGET. Nothing to commit."
+            exit 0
+          fi
+
+          git commit -m ":bookmark: Bump version to $TARGET"
+          git push origin "HEAD:$BRANCH"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -18,10 +18,12 @@ name: Bump version
 # pull request is what carries the bump commit onto `main`, through the front
 # door.
 #
-# Note: pushes made with GITHUB_TOKEN do not start new workflow runs, so CI
-# does not re-run on the bump commit. That commit only rewrites the version
-# field and moves a CHANGELOG heading — the code CI already verified is
-# byte-for-byte the same.
+# Note: GitHub does not run workflows for a push made with GITHUB_TOKEN. It
+# creates the run and parks it as `action_required` with no jobs, so CI does
+# not re-run on the bump commit. That commit only rewrites the version field
+# and moves a CHANGELOG heading — the code CI already verified is byte-for-byte
+# the same. If you want a green tick on the exact commit being merged, approve
+# the parked CI run from the Actions tab (approve CI, not this workflow).
 
 on:
   pull_request:
@@ -41,10 +43,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    # A fork's branch cannot be pushed to with GITHUB_TOKEN. Those pull
+    # Never react to this workflow's own push. GitHub creates a run for it and
+    # parks it as `action_required`; approving that run by hand would make the
+    # job unwind and rewrite the commit it had just written, for no change.
+    #
+    # A fork's branch cannot be pushed to with GITHUB_TOKEN either. Those pull
     # requests get their version set by a maintainer after the merge, or by
     # relabelling once the branch is in this repository.
     if: >-
+      github.actor != 'github-actions[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.event.pull_request.labels.*.name, 'release:skip')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `tsconfig.json` used `moduleResolution: node`, which TypeScript 7 removes
+  outright (`TS5108`). It is now `bundler`, which is what Metro actually does.
+  The emitted `lib/` is byte-for-byte unchanged.
+- `scrollTimeoutRef` was typed `NodeJS.Timeout`. React Native has no `NodeJS`
+  namespace and its `setTimeout` returns a number; the type is now
+  `ReturnType<typeof setTimeout>`.
 - Corrected the `react-native-reanimated` peer range to `>=3.16.0`. The tab bar
   controls (`tabBar.show()` / `hide()` / `reset()`) call `SharedValue.set()`,
   which was added in Reanimated 3.16 — on 3.0 through 3.15 the declared range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Continuous integration: typecheck, unit tests, build, and package verification
   on every push and pull request.
 - Unit tests for the pure helpers in `src/utils.ts`.
-- Release workflow: bumping the version in `package.json` and merging to `main`
+- Label-driven releases. A pull request labelled `release:minor` /
+  `release:major` (or left unlabelled, for a patch) gets its version and
+  CHANGELOG section written into the branch before merge; merging then
   publishes to npm with provenance, pushes the `v<version>` tag, and opens a
-  GitHub Release from this file. Pushes that do not change the version are
-  skipped.
+  GitHub Release from this file. `release:skip` publishes nothing.
 - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and pull request
   templates, and Dependabot configuration.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,9 +131,13 @@ number it would have the first time.
 
 **Two things worth knowing.**
 
-CI does not re-run on the bump commit — pushes made with `GITHUB_TOKEN` do not
-start workflow runs. That commit only rewrites the version field and moves a
-CHANGELOG heading; the code CI verified is unchanged.
+CI does not re-run on the bump commit. GitHub creates a workflow run for a
+push made with `GITHUB_TOKEN` but parks it as *action required* with no jobs,
+so the pull request's head commit carries no green tick. That commit only
+rewrites the version field and moves a CHANGELOG heading; the code CI verified
+is unchanged. If you want the tick on the exact commit being merged, approve
+the parked **CI** run from the Actions tab — not the parked *Bump version* run,
+which would only rewrite the bump commit it had just made.
 
 Pull requests from forks are not bumped, because the bot cannot push to a
 fork's branch. Release those by bumping by hand after the merge, or by moving

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,30 +99,45 @@ When contributing to animated code paths:
 
 ## Releasing
 
-Maintainers only. Merging a version bump into `main` is what releases —
-there is no separate publish step to remember.
+Merging a pull request into `main` is what releases. There is no separate
+publish step to remember, and no version number to type.
 
-1. In a pull request: move the `Unreleased` entries in `CHANGELOG.md` under the
-   new version, and bump `package.json`.
+**How the version is chosen.** Label the pull request:
 
-   ```bash
-   npm version minor --no-git-tag-version   # or patch / major
-   ```
+| Label | 1.2.3 becomes | Use for |
+| --- | --- | --- |
+| *(none)* | `1.2.4` | bug fixes, docs, internals |
+| `release:minor` | `1.3.0` | new options, presets, components |
+| `release:major` | `2.0.0` | anything that breaks existing code |
+| `release:skip` | unchanged | nothing published at all |
 
-   `--no-git-tag-version` matters: the tag is created by CI after a successful
-   publish, so it never points at a release that failed halfway.
+Anything exported from `src/index.ts` is public API, so removing or renaming an
+export — or changing what a prop means — is `release:major`.
 
-2. Merge the pull request.
+**What happens.** The [bump workflow](./.github/workflows/bump.yml) writes the
+new version and moves your `Unreleased` CHANGELOG entries under it, committing
+`:bookmark: Bump version to <version>` to the pull request branch. You see the
+exact number and notes before merging, and can edit them.
 
-The [Release workflow](./.github/workflows/release.yml) then compares
-`package.json` against the registry. If that version is already on npm it stops;
-otherwise it re-runs typecheck, tests and build, publishes with provenance,
-pushes the `v<version>` tag, and opens a GitHub Release using the matching
-`CHANGELOG.md` section.
+Merging carries that commit onto `main`, where the
+[release workflow](./.github/workflows/release.yml) sees a version the registry
+does not have yet, re-runs typecheck/tests/build, publishes with provenance,
+pushes the `v<version>` tag, and opens a GitHub Release from the CHANGELOG
+section.
 
-Choosing the version number stays a human decision — nothing infers semver from
-commit messages. Note that anything exported from `src/index.ts` is public API
-(see above), so removals and renames need a major bump.
+The target is always computed from `main`, never from the branch, so
+re-labelling is safe: minor, then major, then minor again lands on the same
+number it would have the first time.
+
+**Two things worth knowing.**
+
+CI does not re-run on the bump commit — pushes made with `GITHUB_TOKEN` do not
+start workflow runs. That commit only rewrites the version field and moves a
+CHANGELOG heading; the code CI verified is unchanged.
+
+Pull requests from forks are not bumped, because the bot cannot push to a
+fork's branch. Release those by bumping by hand after the merge, or by moving
+the branch into this repository.
 
 ## Questions
 

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Promotes the `Unreleased` section of CHANGELOG.md into a released section.
+ *
+ * The release workflow runs this after bumping the version, so the file on
+ * `main` keeps describing what was actually published instead of accumulating
+ * everything under `Unreleased` forever.
+ *
+ * Prints one word so the caller knows what happened:
+ *   promoted — the section was moved and the compare links rewritten
+ *   empty    — `Unreleased` had nothing in it, so the file was left alone
+ *
+ * Usage: node scripts/release-changelog.mjs <version> <YYYY-MM-DD>
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [version, date] = process.argv.slice(2);
+
+if (!version || !date) {
+  console.error("usage: release-changelog.mjs <version> <YYYY-MM-DD>");
+  process.exit(2);
+}
+
+const FILE = "CHANGELOG.md";
+const HEADING = "## [Unreleased]";
+
+const original = readFileSync(FILE, "utf8");
+
+const start = original.indexOf(HEADING);
+if (start === -1) {
+  console.error(`${FILE} has no "${HEADING}" heading.`);
+  process.exit(1);
+}
+
+// The body runs from the end of the heading to the next `## ` heading. The
+// link-reference block at the bottom starts with `[`, so it is never mistaken
+// for a section.
+const bodyStart = start + HEADING.length;
+const nextHeading = original.indexOf("\n## ", bodyStart);
+const bodyEnd = nextHeading === -1 ? original.length : nextHeading + 1;
+const body = original.slice(bodyStart, bodyEnd);
+
+if (body.trim() === "") {
+  console.log("empty");
+  process.exit(0);
+}
+
+const released = `## [${version}] - ${date}\n\n${body.trim()}\n\n`;
+
+let updated =
+  original.slice(0, start) + `${HEADING}\n\n` + released + original.slice(bodyEnd);
+
+// Repoint `[unreleased]` at the new tag and add a compare link for this
+// version, reusing whatever host and repository path the file already uses.
+const unreleasedLink = /^\[unreleased\]:\s*(\S+?)\/compare\/(\S+?)\.\.\.HEAD\s*$/im;
+const match = updated.match(unreleasedLink);
+
+if (!match) {
+  console.error(`${FILE} has no "[unreleased]: .../compare/<tag>...HEAD" link.`);
+  process.exit(1);
+}
+
+const [, base, previousTag] = match;
+
+updated = updated.replace(
+  unreleasedLink,
+  `[unreleased]: ${base}/compare/v${version}...HEAD\n` +
+    `[${version}]: ${base}/compare/${previousTag}...v${version}`
+);
+
+writeFileSync(FILE, updated);
+console.log("promoted");

--- a/src/MotionifyProvider.tsx
+++ b/src/MotionifyProvider.tsx
@@ -114,7 +114,9 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
   const previousYRef = useRef(0);
   const scrollStartYRef = useRef(0);
   const isUserScrollingRef = useRef(false);
-  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // `ReturnType<typeof setTimeout>` rather than `NodeJS.Timeout`: React Native
+  // has no NodeJS namespace, and its setTimeout returns a number.
+  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const thresholdRef = useRef(threshold);
   const supportIdleRef = useRef(supportIdle);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,


### PR DESCRIPTION
Releases needed a version number typed into `package.json` by hand before merge. This replaces that with a label on the pull request.

| Label | 1.2.3 becomes | Use for |
| --- | --- | --- |
| *(none)* | `1.2.4` | bug fixes, docs, internals |
| `release:minor` | `1.3.0` | new behaviour that stays compatible |
| `release:major` | `2.0.0` | anything that breaks existing code |
| `release:skip` | unchanged | nothing published at all |

## Why the bump lands in the pull request, not on `main`

The obvious shape is: merge, then have CI bump and commit to `main`. That does not work here, and the reason is worth recording.

`main` has **Require a pull request before merging** enabled. That blocks direct pushes from everyone without a bypass, including `github-actions[bot]`. The documented fix is a bypass allowance for the Actions app — `PATCH /repos/{owner}/{repo}/branches/main/protection/required_pull_request_reviews` with `bypass_pull_request_allowances.apps: ["github-actions"]`. On these repositories that call returns **HTTP 500**: bypass allowances are an organisation feature, and these are personal repositories.

So the bump is written into the pull request branch instead, which is not protected. Merging carries the commit onto `main` through the front door. Branch protection is untouched.

This turned out better than the original shape anyway: you see the version number and the CHANGELOG section **before** merging, and can edit either.

## What changed

**`.github/workflows/bump.yml`** (new) — on pull request open/reopen/synchronize/label/unlabel, computes the target version, writes it, promotes the CHANGELOG section, and commits `:bookmark: Bump version to <version>` to the branch.

The target is computed from **`main`**, never from the branch's own `package.json`. That makes it idempotent: label a pull request minor, then major, then minor again, and it lands on the number it would have had the first time. The bump itself goes through `npm version` rather than string arithmetic, so semver edge cases are npm's problem.

Fork pull requests are skipped — `GITHUB_TOKEN` cannot push to a fork's branch. So are `release:skip` ones.

**`scripts/release-changelog.mjs`** (new) — moves the `Unreleased` section under a dated version heading and rewrites the compare links, reusing whatever repository path the file already contains. Prints `promoted` or `empty` so the caller knows whether notes can be read back out.

**`.github/workflows/release.yml`** — unchanged. It already publishes whenever `main` carries a version the registry does not have, which is exactly the state a merged bump commit produces.

**`.github/dependabot.yml`** — every Dependabot pull request now carries `release:skip`, so dependency bumps never publish on their own. `github-actions` and the example app are grouped into one pull request each instead of one per dependency. `typescript` is excluded from the `dev-dependencies` group: TS 7 is a breaking bump, and grouping it meant one red pull request holding four green ones hostage.

**`CONTRIBUTING.md`** — the release section now documents the labels rather than a manual `npm version` command.

## Also in here: the TypeScript 7 failure Dependabot found

Dependabot's #11 went red with `TS5108: Option 'moduleResolution=node10' has been removed`. `tsconfig.json` was on `"node"`, which is an alias for `node10`. Checked against 7.0.2 — the surviving values are `bundler`, `node16`, `nodenext`. `node16`/`nodenext` apply Node's CommonJS/ESM interop rules and then refuse the Reanimated import with `TS1479`. `bundler` is what Metro actually does, and the emitted `lib/index.js` comes out byte-for-byte identical.

Fixing that exposed a second bug `node10`'s directory walk had been hiding: `scrollTimeoutRef` was typed `NodeJS.Timeout`. React Native has no `NodeJS` namespace, and its `setTimeout` returns a number, not a Timeout object. Now `ReturnType<typeof setTimeout>`.

**Dependabot grouping** — at most two pull requests per ecosystem instead of one per dependency. Minor and patch travel together; majors travel separately, because majors are where breakage lives and the old config let TypeScript 7 hold four harmless bumps hostage.

## Testing

Version targeting, run against the real `package.json`:

| From | Label | Target |
| --- | --- | --- |
| 1.0.3 | *(none)* | 1.0.4 |
| 1.0.3 | `release:minor` | 1.1.0 |
| 1.0.3 | `release:major` | 2.0.0 |

Running the minor path three times consecutively produced `1.1.0` every time, and `npm pkg set` / `npm version` left the rest of the file byte-identical — no formatting drift in the diff.

`scripts/release-changelog.mjs` was run against both repositories' real `CHANGELOG.md`: the section lands with correct spacing, `[unreleased]` is repointed at the new tag, a compare link is inserted for the new version, and a second run against the now-empty `Unreleased` correctly reports `empty` and leaves the file alone.

Both workflow files and both `dependabot.yml` files parse.

`bump.yml` was then exercised on a throwaway pull request against this repository, since a workflow that has never run is not a workflow you can trust:

| Step | Result |
| --- | --- |
| no label | `Labels: <none> -> patch. 1.0.3 -> 1.0.4.`, committed `:bookmark: Bump version to 1.0.4` |
| add `release:minor` | `1.0.3 -> 1.1.0` — computed from `main`, not `1.0.4 -> 1.0.5` |
| remove the label | replaced with a single `1.0.4` commit rather than stacking a third |

The relabel case is what produced the `Unwind the previous bump` step: the first attempt stacked two bump commits and left the CHANGELOG heading naming the version no longer being released. It also produced the `github.actor != 'github-actions[bot]'` guard, after approving the parked run made the job rewrite the commit it had just written.

The TypeScript 7 fix was checked against the exact dependency set #11 carries — typescript 7.0.2, @types/react 19.2.18, react-native 0.86.2 — not just against TS 7 alone: typecheck clean, 24 tests pass, build emits `lib/index.js` and `lib/index.d.ts`, and the emitted JS is byte-identical to the TypeScript 5 output.

**Not covered:** the publish step still has not run — that needs a trusted publisher configured on npm first. This pull request is labelled `release:skip`, so merging it publishes nothing; see the sequencing note below.

## Risk

The failure mode worth naming: **CI does not re-run on the bump commit.** Pushes made with `GITHUB_TOKEN` do not start workflow runs, so after the bot pushes, the pull request's head commit has no checks attached. The commit rewrites a version field and moves a CHANGELOG heading — the code CI verified is byte-for-byte identical — but the green tick will be sitting on the previous commit rather than the one being merged. Getting checks onto that commit would require a personal access token stored as a secret, which is a worse trade.

Nothing here can publish by itself. A release still requires a version on `main` that npm does not have.

## Sequencing

This pull request carries a source fix that deserves to be released, but it is labelled `release:skip` so that merging is safe no matter what state npm auth is in.

The clean order is: configure the trusted publisher on npm, **then** swap `release:skip` for no label on this pull request, let `bump.yml` write `1.0.4`, and merge. That is one clean release.

Merging as-is is also fine — the fix simply sits on `main` unreleased until the next labelled pull request goes out.
