### PR TITLE
TEST: exercise the bump workflow — do not merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,47 @@
 version: 2
 
+# Every Dependabot pull request carries `release:skip`. Merging one publishes
+# nothing on its own — dependency bumps here are development-only and do not
+# change the shipped library. Remove the label from a pull request that should
+# go out as a release.
+
 updates:
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels: ["dependencies", "release:skip"]
     commit-message:
       prefix: "chore(deps)"
     groups:
       dev-dependencies:
         dependency-type: development
+        # TypeScript majors remove compiler options outright, so they need a
+        # tsconfig migration rather than a routine merge. Keeping them out of
+        # the group means one red pull request instead of a red group that
+        # blocks four green bumps.
+        exclude-patterns: ["typescript"]
 
   - package-ecosystem: npm
     directory: /example
     schedule:
       interval: monthly
     open-pull-requests-limit: 3
+    labels: ["dependencies", "release:skip"]
     commit-message:
       prefix: "chore(example-deps)"
+    groups:
+      example:
+        patterns: ["*"]
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    labels: ["dependencies", "release:skip"]
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -66,6 +66,24 @@ jobs:
       - name: Fetch main
         run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
 
+      # Drop the previous run's bump before recomputing. Without this,
+      # relabelling stacks a second bump commit on top of the first and leaves
+      # the CHANGELOG heading naming the version that is no longer being
+      # released. Only ever unwinds this workflow's own commit — a human push
+      # on top makes HEAD something else, and nothing is touched.
+      - name: Unwind the previous bump
+        id: unwind
+        run: |
+          if [ "$(git log -1 --format=%an)" = "github-actions[bot]" ]; then
+            case "$(git log -1 --format=%s)" in
+              ":bookmark: Bump version to "*)
+                echo "Dropping $(git log -1 --format=%s) to recompute from scratch."
+                git reset --hard HEAD~1
+                echo "unwound=true" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          fi
+
       - name: Work out the target version
         id: target
         env:
@@ -118,16 +136,25 @@ jobs:
         env:
           TARGET: ${{ steps.target.outputs.target }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
+          UNWOUND: ${{ steps.unwind.outputs.unwound }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add package.json CHANGELOG.md
 
+          # Nothing staged means the recomputed result matches what is already
+          # on the branch, so the remote is left exactly as it is — including
+          # in the unwound case, where the commit that was dropped locally was
+          # already correct.
           if git diff --cached --quiet; then
             echo "Already set to $TARGET. Nothing to commit."
             exit 0
           fi
 
           git commit -m ":bookmark: Bump version to $TARGET"
-          git push origin "HEAD:$BRANCH"
+
+          # `--force-with-lease` only because the previous bump was unwound.
+          # It refuses if anyone pushed since this job fetched, so a
+          # contributor's work cannot be overwritten.
+          git push --force-with-lease origin "HEAD:$BRANCH"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,133 @@
+name: Bump version
+
+# Writes the version a pull request will release into the pull request itself,
+# so the number is visible — and editable — before anyone merges.
+#
+#   release:skip    no bump; merging publishes nothing
+#   release:major   next major after the version on `main`
+#   release:minor   next minor
+#   (no label)      next patch
+#
+# The target is always computed from `main`, never from the pull request's own
+# package.json, so re-running this cannot make the version climb: label a pull
+# request minor, then major, then minor again, and it lands on the same number
+# it would have had the first time.
+#
+# The bump lives here rather than in the release workflow because `main`
+# requires a pull request, and the Actions bot cannot push to it. Merging the
+# pull request is what carries the bump commit onto `main`, through the front
+# door.
+#
+# Note: pushes made with GITHUB_TOKEN do not start new workflow runs, so CI
+# does not re-run on the bump commit. That commit only rewrites the version
+# field and moves a CHANGELOG heading — the code CI already verified is
+# byte-for-byte the same.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bump-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    name: Set the release version
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # A fork's branch cannot be pushed to with GITHUB_TOKEN. Those pull
+    # requests get their version set by a maintainer after the merge, or by
+    # relabelling once the branch is in this repository.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'release:skip')
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      # Every comparison below is against `main`. Fetch it explicitly rather
+      # than relying on checkout having left a usable remote-tracking ref.
+      - name: Fetch main
+        run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Work out the target version
+        id: target
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: |
+          case " $LABELS " in
+            *" release:major "*) BUMP=major ;;
+            *" release:minor "*) BUMP=minor ;;
+            *) BUMP=patch ;;
+          esac
+
+          BASE="$(git show origin/main:package.json \
+            | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")"
+
+          # Compute the target with npm's own semver rather than string
+          # arithmetic: reset to what `main` carries, then bump once.
+          npm pkg set "version=$BASE" > /dev/null
+          npm version "$BUMP" --no-git-tag-version --allow-same-version > /dev/null
+
+          TARGET="$(node -p "require('./package.json').version")"
+          echo "Labels: ${LABELS:-<none>} -> $BUMP. $BASE -> $TARGET."
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+      - name: Promote the CHANGELOG entry
+        env:
+          TARGET: ${{ steps.target.outputs.target }}
+        run: |
+          # Any `## [x.y.z]` heading that this branch has and `main` does not is
+          # one this workflow wrote earlier. If it names a different version —
+          # because the release label changed after the fact — say so loudly
+          # rather than silently leaving the CHANGELOG describing the wrong
+          # release.
+          ADDED="$(comm -13 \
+            <(git show origin/main:CHANGELOG.md | grep -o '^## \[[^]]*\]' | sort -u) \
+            <(grep -o '^## \[[^]]*\]' CHANGELOG.md | sort -u))"
+
+          if [ -n "$ADDED" ] && [ "$ADDED" != "## [$TARGET]" ]; then
+            echo "::warning::CHANGELOG.md has a section for $ADDED but this pull request now releases $TARGET. Rename that heading by hand."
+            exit 0
+          fi
+
+          if [ -n "$ADDED" ]; then
+            echo "CHANGELOG.md already has a section for $TARGET."
+            exit 0
+          fi
+
+          echo "CHANGELOG: $(node scripts/release-changelog.mjs "$TARGET" "$(date -u +%Y-%m-%d)")"
+
+      - name: Commit the bump
+        env:
+          TARGET: ${{ steps.target.outputs.target }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add package.json CHANGELOG.md
+
+          if git diff --cached --quiet; then
+            echo "Already set to $TARGET. Nothing to commit."
+            exit 0
+          fi
+
+          git commit -m ":bookmark: Bump version to $TARGET"
+          git push origin "HEAD:$BRANCH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Continuous integration: typecheck, unit tests, build, and package verification
   on every push and pull request.
 - Unit tests for the pure helpers in `src/utils.ts`.
-- Release workflow: bumping the version in `package.json` and merging to `main`
+- Label-driven releases. A pull request labelled `release:minor` /
+  `release:major` (or left unlabelled, for a patch) gets its version and
+  CHANGELOG section written into the branch before merge; merging then
   publishes to npm with provenance, pushes the `v<version>` tag, and opens a
-  GitHub Release from this file. Pushes that do not change the version are
-  skipped.
+  GitHub Release from this file. `release:skip` publishes nothing.
 - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue and pull request
   templates, and Dependabot configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-08-11
+
 ### Fixed
 
 - Corrected the `react-native-reanimated` peer range to `>=3.16.0`. The tab bar
@@ -71,7 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MotionifyBottomTabWithInterpolation`, plus translation and interpolation
   presets and helper utilities.
 
-[unreleased]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.3...HEAD
+[unreleased]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/dennytosp/react-native-motionify/compare/v1.0.0...v1.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,30 +99,45 @@ When contributing to animated code paths:
 
 ## Releasing
 
-Maintainers only. Merging a version bump into `main` is what releases —
-there is no separate publish step to remember.
+Merging a pull request into `main` is what releases. There is no separate
+publish step to remember, and no version number to type.
 
-1. In a pull request: move the `Unreleased` entries in `CHANGELOG.md` under the
-   new version, and bump `package.json`.
+**How the version is chosen.** Label the pull request:
 
-   ```bash
-   npm version minor --no-git-tag-version   # or patch / major
-   ```
+| Label | 1.2.3 becomes | Use for |
+| --- | --- | --- |
+| *(none)* | `1.2.4` | bug fixes, docs, internals |
+| `release:minor` | `1.3.0` | new options, presets, components |
+| `release:major` | `2.0.0` | anything that breaks existing code |
+| `release:skip` | unchanged | nothing published at all |
 
-   `--no-git-tag-version` matters: the tag is created by CI after a successful
-   publish, so it never points at a release that failed halfway.
+Anything exported from `src/index.ts` is public API, so removing or renaming an
+export — or changing what a prop means — is `release:major`.
 
-2. Merge the pull request.
+**What happens.** The [bump workflow](./.github/workflows/bump.yml) writes the
+new version and moves your `Unreleased` CHANGELOG entries under it, committing
+`:bookmark: Bump version to <version>` to the pull request branch. You see the
+exact number and notes before merging, and can edit them.
 
-The [Release workflow](./.github/workflows/release.yml) then compares
-`package.json` against the registry. If that version is already on npm it stops;
-otherwise it re-runs typecheck, tests and build, publishes with provenance,
-pushes the `v<version>` tag, and opens a GitHub Release using the matching
-`CHANGELOG.md` section.
+Merging carries that commit onto `main`, where the
+[release workflow](./.github/workflows/release.yml) sees a version the registry
+does not have yet, re-runs typecheck/tests/build, publishes with provenance,
+pushes the `v<version>` tag, and opens a GitHub Release from the CHANGELOG
+section.
 
-Choosing the version number stays a human decision — nothing infers semver from
-commit messages. Note that anything exported from `src/index.ts` is public API
-(see above), so removals and renames need a major bump.
+The target is always computed from `main`, never from the branch, so
+re-labelling is safe: minor, then major, then minor again lands on the same
+number it would have the first time.
+
+**Two things worth knowing.**
+
+CI does not re-run on the bump commit — pushes made with `GITHUB_TOKEN` do not
+start workflow runs. That commit only rewrites the version field and moves a
+CHANGELOG heading; the code CI verified is unchanged.
+
+Pull requests from forks are not bumped, because the bot cannot push to a
+fork's branch. Release those by bumping by hand after the merge, or by moving
+the branch into this repository.
 
 ## Questions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-motionify",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A lightweight library for smooth, scroll-driven UI with Reanimated 3.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Promotes the `Unreleased` section of CHANGELOG.md into a released section.
+ *
+ * The release workflow runs this after bumping the version, so the file on
+ * `main` keeps describing what was actually published instead of accumulating
+ * everything under `Unreleased` forever.
+ *
+ * Prints one word so the caller knows what happened:
+ *   promoted — the section was moved and the compare links rewritten
+ *   empty    — `Unreleased` had nothing in it, so the file was left alone
+ *
+ * Usage: node scripts/release-changelog.mjs <version> <YYYY-MM-DD>
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [version, date] = process.argv.slice(2);
+
+if (!version || !date) {
+  console.error("usage: release-changelog.mjs <version> <YYYY-MM-DD>");
+  process.exit(2);
+}
+
+const FILE = "CHANGELOG.md";
+const HEADING = "## [Unreleased]";
+
+const original = readFileSync(FILE, "utf8");
+
+const start = original.indexOf(HEADING);
+if (start === -1) {
+  console.error(`${FILE} has no "${HEADING}" heading.`);
+  process.exit(1);
+}
+
+// The body runs from the end of the heading to the next `## ` heading. The
+// link-reference block at the bottom starts with `[`, so it is never mistaken
+// for a section.
+const bodyStart = start + HEADING.length;
+const nextHeading = original.indexOf("\n## ", bodyStart);
+const bodyEnd = nextHeading === -1 ? original.length : nextHeading + 1;
+const body = original.slice(bodyStart, bodyEnd);
+
+if (body.trim() === "") {
+  console.log("empty");
+  process.exit(0);
+}
+
+const released = `## [${version}] - ${date}\n\n${body.trim()}\n\n`;
+
+let updated =
+  original.slice(0, start) + `${HEADING}\n\n` + released + original.slice(bodyEnd);
+
+// Repoint `[unreleased]` at the new tag and add a compare link for this
+// version, reusing whatever host and repository path the file already uses.
+const unreleasedLink = /^\[unreleased\]:\s*(\S+?)\/compare\/(\S+?)\.\.\.HEAD\s*$/im;
+const match = updated.match(unreleasedLink);
+
+if (!match) {
+  console.error(`${FILE} has no "[unreleased]: .../compare/<tag>...HEAD" link.`);
+  process.exit(1);
+}
+
+const [, base, previousTag] = match;
+
+updated = updated.replace(
+  unreleasedLink,
+  `[unreleased]: ${base}/compare/v${version}...HEAD\n` +
+    `[${version}]: ${base}/compare/${previousTag}...v${version}`
+);
+
+writeFileSync(FILE, updated);
+console.log("promoted");


### PR DESCRIPTION
Throwaway pull request used to verify that `bump.yml` actually runs on GitHub. No label, so it should bump patch: 1.0.3 -> 1.0.4, promote the CHANGELOG section, and commit `:bookmark: Bump version to 1.0.4` to this branch.

Closing without merging once checked.