### PR TITLE
ci: support explicit version releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,8 @@
 
 <!-- Select exactly one. See RELEASING.md for the label commands. -->
 
-- [ ] Skip npm release — no `release:*` label
+- [ ] Skip npm release — no `release:*` label and package version unchanged
+- [ ] Exact version — increase `package.json.version`, no release label
 - [ ] Patch — `release:patch`
 - [ ] Minor — `release:minor`
 - [ ] Major — `release:major`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,8 @@ version: 2
 # `moduleResolution=node10` should not be able to hold four harmless bumps
 # hostage in the same pull request.
 #
-# Published-package and workflow dependencies request a patch release. The
-# example app is not shipped to npm, so its updates have no release label and
-# use the default skip decision.
+# Dependabot pull requests only update dependencies. They use the default skip
+# decision unless a maintainer explicitly adds a release label before merge.
 
 updates:
   - package-ecosystem: npm
@@ -18,7 +17,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    labels: ["dependencies", "release:patch"]
+    labels: ["dependencies"]
     commit-message:
       prefix: "chore(deps)"
     groups:
@@ -49,7 +48,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels: ["dependencies", "release:patch"]
+    labels: ["dependencies"]
     commit-message:
       prefix: "chore(ci)"
     groups:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,8 +1,9 @@
 name: Release merged changes
 
-# A source pull request never receives a version commit. CI verifies the merged
-# main commit first; only then does trusted code select the highest release
-# label since the latest tag and commit the version bump directly to main.
+# A source pull request never receives an automatic version commit. CI verifies
+# the merged main commit first. A manually increased package version publishes
+# as-is; otherwise trusted code selects the highest release label since the
+# latest tag and commits the version bump directly to main.
 
 on:
   workflow_run:
@@ -67,18 +68,13 @@ jobs:
         run: |
           BASE_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
           TAG_VERSION="${BASE_TAG#v}"
-          MAIN_VERSION="$(node -p "require('./package.json').version")"
-
-          if [ "$MAIN_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::main is version $MAIN_VERSION but the latest tag is $BASE_TAG. Repair that release with release.yml before bumping again."
-            exit 1
-          fi
-
+          RELEASED_VERSION="$TAG_VERSION" node scripts/check-release-version.mjs
           echo "base_tag=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Collect merged release decisions
         id: decision
-        if: steps.current.outputs.ready == 'true'
+        if: steps.current.outputs.ready == 'true' && steps.baseline.outputs.status == 'same'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_BASE_BRANCH: main
@@ -87,7 +83,7 @@ jobs:
 
       - name: Create the version commit
         id: release
-        if: steps.current.outputs.ready == 'true' && steps.decision.outputs.bump != 'skip'
+        if: steps.current.outputs.ready == 'true' && steps.baseline.outputs.status == 'same' && steps.decision.outputs.bump != 'skip'
         env:
           BUMP: ${{ steps.decision.outputs.bump }}
         run: |
@@ -105,7 +101,7 @@ jobs:
 
       - name: Verify the version commit
         id: verification
-        if: steps.current.outputs.ready == 'true' && steps.decision.outputs.bump != 'skip'
+        if: steps.current.outputs.ready == 'true' && steps.baseline.outputs.status == 'same' && steps.decision.outputs.bump != 'skip'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ steps.release.outputs.sha }}
@@ -150,7 +146,7 @@ jobs:
 
       - name: Push the verified version to main
         id: push
-        if: steps.current.outputs.ready == 'true' && steps.decision.outputs.bump != 'skip'
+        if: steps.current.outputs.ready == 'true' && steps.baseline.outputs.status == 'same' && steps.decision.outputs.bump != 'skip'
         env:
           RELEASE_BRANCH: ${{ steps.verification.outputs.branch }}
           RELEASE_SHA: ${{ steps.release.outputs.sha }}
@@ -171,11 +167,29 @@ jobs:
       # npm validates the workflow that starts a run. Dispatching release.yml
       # preserves its trusted-publisher identity; workflow_call would expose
       # bump.yml as the caller and fail npm authentication.
+      - name: Recheck the manual release head
+        id: manual
+        if: steps.baseline.outputs.status == 'ahead'
+        env:
+          RELEASE_SHA: ${{ steps.baseline.outputs.release_sha }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+
+          if [ "$RELEASE_SHA" != "$(git rev-parse origin/main)" ]; then
+            echo "::notice::main advanced before the manual release; its newer CI run will publish the version."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch and wait for the release
-        if: steps.push.outputs.pushed == 'true'
+        if: >-
+          (steps.baseline.outputs.status == 'ahead' && steps.manual.outputs.ready == 'true') ||
+          steps.push.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+          RELEASE_SHA: ${{ steps.baseline.outputs.status == 'ahead' && steps.baseline.outputs.release_sha || steps.release.outputs.sha }}
         run: |
           RUN_TITLE="Release $RELEASE_SHA ($GITHUB_RUN_ID)"
           gh workflow run release.yml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Guard package version
+        run: |
+          BASE_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
+          RELEASED_VERSION="${BASE_TAG#v}" node scripts/check-release-version.mjs
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.sha }}
+          fetch-depth: 0
+
+      - name: Guard package version
+        run: |
+          BASE_TAG="$(git describe --tags --abbrev=0 --match 'v[0-9]*')"
+          RELEASED_VERSION="${BASE_TAG#v}" node scripts/check-release-version.mjs
 
       - id: check
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Dependabot updates now skip npm publishing by default. Explicit package
+  version increases publish after required CI, while version decreases are
+  rejected.
+
 ## [1.0.4] - 2026-08-11
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,12 @@ When contributing to animated code paths:
 
 ## Releasing
 
-Source pull requests never bump their own version. After a merge into `main`,
-the default decision is to skip publishing when no `release:*` label is
-present. Use `release:patch`, `release:minor`, or `release:major` to publish.
-Automation then commits the selected version directly to `main`, verifies the
-package, publishes it to npm, and creates the matching tag and GitHub Release.
+Source pull requests normally leave the package version unchanged. After a
+merge into `main`, the default decision is to skip publishing when no
+`release:*` label is present. Use `release:patch`, `release:minor`, or
+`release:major` to publish, or explicitly increase `package.json.version` to
+publish that exact version without a label. Automation verifies the package,
+publishes it to npm, and creates the matching tag and GitHub Release.
 
 Read [RELEASING.md](./RELEASING.md) for the complete rules and copy-pasteable
 `gh` commands for creating, applying, changing, and verifying release labels.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
-Releases are selected with pull request labels. Pull request titles and commit
-messages do not determine the version.
+Releases are selected with pull request labels or an explicit package version
+increase. Pull request titles and commit messages do not determine the version.
 
 ## Release decisions
 
@@ -10,12 +10,14 @@ Choose exactly one release decision for every source pull request targeting
 
 | Decision | Pull request label | `1.2.3` becomes | Use for |
 | --- | --- | --- | --- |
-| Skip | No `release:*` label | Unchanged | Changes that must not publish a new npm version |
+| Skip | No label, version unchanged | Unchanged | Changes that must not publish a new npm version |
+| Exact | No label, version increased | Exact value | A manual stable-version release |
 | Patch | `release:patch` | `1.2.4` | Backwards-compatible fixes and small internal changes |
 | Minor | `release:minor` | `1.3.0` | Backwards-compatible features, props, presets, or components |
 | Major | `release:major` | `2.0.0` | Breaking changes to public exports or behavior |
 
-Skip is the default. Publishing always requires an explicit release label.
+Skip is the default for changes that keep the current package version. An
+explicit version increase in `package.json` is the manual-release exception.
 
 Only one `release:*` label should be present. If conflicting labels are
 accidentally applied, the highest version wins: major, then minor, then patch.
@@ -103,11 +105,20 @@ gh pr view "$PR_NUMBER" \
 
 Interpret the output as follows:
 
-- `[]` means no npm release.
+- `[]` means no label-driven release; a higher package version still publishes
+  that exact version.
 - `["release:patch"]` means patch.
 - `["release:minor"]` means minor.
 - `["release:major"]` means major.
 - More than one value is a conflict; apply one of the commands above again.
+
+## Manual version bump
+
+To choose the exact next version yourself, update only the stable semantic
+version in `package.json`, for example `1.0.4` to `1.0.5`. No release label is
+required. Required CI rejects a version lower than the latest `v*` tag. After a
+higher version reaches `main` and its CI passes, automation publishes that
+exact version without applying another bump.
 
 ## What automation does
 
@@ -115,12 +126,14 @@ Source pull requests run format, lint, typecheck, test, build, and package
 checks without changing `package.json` or `CHANGELOG.md`. GitHub requires the
 CI checks to pass before the pull request can be merged into `main`.
 
-After the merged `main` commit passes CI, the release workflow examines every
-merged change since the latest `v*` tag. It uses the highest requested decision
-— major, then minor, then patch — and creates the version and CHANGELOG commit.
-That exact commit must pass required CI on a temporary release branch before it
-can fast-forward protected `main`. A stale CI run does nothing when a newer
-`main` commit is already being verified.
+After the merged `main` commit passes CI, a manually increased package version
+publishes as-is. When the package version still matches the latest `v*` tag,
+the release workflow instead examines every merged change since that tag. It
+uses the highest requested decision — major, then minor, then patch — and
+creates the version and CHANGELOG commit. That exact commit must pass required
+CI on a temporary release branch before it can fast-forward protected `main`.
+A stale CI run does nothing when a newer `main` commit is already being
+verified.
 
 The same workflow dispatches `release.yml` for that exact commit and waits for
 it to finish. The release repeats the quality checks, publishes to npm with
@@ -132,11 +145,11 @@ twice, but missing tags or GitHub Releases are still repaired.
 
 - Pull requests without a release label are ignored when the next version is
   selected.
-- Dependency updates for the published package and GitHub Actions carry
-  `release:patch`. Updates confined to `/example` have no release label because
-  the example app is not included in the npm package.
-- If the version on `main` differs from the latest `v*` tag, release
-  preparation stops instead of bumping again. Repair the interrupted release
-  with `gh workflow run release.yml`; if unreleased merged changes remain, run
-  `gh workflow run bump.yml` afterward.
+- Dependabot pull requests have no release label and therefore do not publish
+  by default. Add an explicit release label before merge only when the
+  dependency update must produce a new package version.
+- A package version higher than the latest `v*` tag is an explicit manual
+  release. A lower version fails required CI and cannot enter protected `main`.
+- Repair an interrupted publish, tag, or GitHub Release with
+  `gh workflow run release.yml`.
 - npm publishing requires the configured trusted publisher for `release.yml`.

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function parseStableVersion(version) {
+  const match = STABLE_VERSION.exec(version);
+
+  if (!match) {
+    throw new Error(
+      `Expected a stable semantic version (x.y.z), received: ${version}`,
+    );
+  }
+
+  return match.slice(1).map(BigInt);
+}
+
+export function compareStableVersions(current, released) {
+  const currentParts = parseStableVersion(current);
+  const releasedParts = parseStableVersion(released);
+
+  for (let index = 0; index < currentParts.length; index += 1) {
+    if (currentParts[index] > releasedParts[index]) return 1;
+    if (currentParts[index] < releasedParts[index]) return -1;
+  }
+
+  return 0;
+}
+
+export function classifyPackageVersion(current, released) {
+  const comparison = compareStableVersions(current, released);
+  if (comparison > 0) return "ahead";
+  if (comparison < 0) return "behind";
+  return "same";
+}
+
+function main() {
+  const released = process.env.RELEASED_VERSION;
+  const outputFile = process.env.GITHUB_OUTPUT;
+  const { version: current } = JSON.parse(readFileSync("package.json", "utf8"));
+
+  if (!released) {
+    throw new Error("RELEASED_VERSION is required.");
+  }
+
+  const status = classifyPackageVersion(current, released);
+
+  if (status === "behind") {
+    throw new Error(
+      `package.json version ${current} is lower than released version ${released}.`,
+    );
+  }
+
+  if (outputFile) {
+    appendFileSync(outputFile, `status=${status}\nversion=${current}\n`);
+  }
+
+  console.log(
+    status === "ahead"
+      ? `Manual version bump detected: ${released} -> ${current}.`
+      : `Package version matches the latest release: ${current}.`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/test/release-decision.test.mjs
+++ b/test/release-decision.test.mjs
@@ -4,6 +4,35 @@ import {
   classifyRelease,
   highestRelease,
 } from "../scripts/collect-release-decision.mjs";
+import {
+  classifyPackageVersion,
+  parseStableVersion,
+} from "../scripts/check-release-version.mjs";
+
+describe("package version policy", () => {
+  test("accepts the released version", () => {
+    expect(classifyPackageVersion("1.0.4", "1.0.4")).toBe("same");
+  });
+
+  test("detects a manual version bump", () => {
+    expect(classifyPackageVersion("1.0.5", "1.0.4")).toBe("ahead");
+    expect(classifyPackageVersion("1.1.0", "1.0.4")).toBe("ahead");
+    expect(classifyPackageVersion("2.0.0", "1.0.4")).toBe("ahead");
+    expect(
+      classifyPackageVersion("9007199254740993.0.0", "9007199254740992.0.0"),
+    ).toBe("ahead");
+  });
+
+  test("rejects a version lower than the latest release", () => {
+    expect(classifyPackageVersion("1.0.3", "1.0.4")).toBe("behind");
+    expect(classifyPackageVersion("0.99.0", "1.0.4")).toBe("behind");
+  });
+
+  test("requires a stable semantic version", () => {
+    expect(() => parseStableVersion("1.0.5-beta.1")).toThrow();
+    expect(() => parseStableVersion("v1.0.5")).toThrow();
+  });
+});
 
 describe("release decisions", () => {
   test("skips pull requests without a release label", () => {


### PR DESCRIPTION
Make dependency maintenance release-neutral by default while supporting an exact package version chosen by a maintainer.

## What changed

- remove automatic release labels from Dependabot npm and GitHub Actions updates
- reject stable package versions lower than the latest release in required CI
- publish an explicitly increased `package.json` version after successful `main` CI without requiring a release label
- preserve the existing label-driven patch, minor, and major release flow
- document and test the version policy

## Testing

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 32 tests passed
- `bun run build`
- YAML parsing and `git diff --check`
- independent release-workflow review completed with no remaining critical or important findings

## Risk

Release automation changes are guarded by exact version comparison, required CI, a fresh `origin/main` check before dispatch, and the existing npm Trusted Publisher workflow.
