### PR TITLE
fix: isolate scroll configuration by consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply the configured direction threshold symmetrically to upward and
+  downward scrolling.
+- Scope `useMotionify({ threshold, supportIdle })` to the hook's returned
+  scroll handler so multiple mounted screens no longer overwrite provider
+  configuration or churn effects during scrolling.
+
 ### Changed
 
 - Dependabot updates now skip npm publishing by default. Explicit package

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Notes:
 
 `<MotionifyProvider threshold={8} supportIdle={false}>`
 
-- **threshold**: number — pixels to switch direction
+- **threshold**: number — pixels that must be exceeded to switch direction
 - **supportIdle**: boolean — emit `idle` after inactivity
 
 ### Hook
@@ -265,6 +265,20 @@ Returns:
 - **tabBar**: Tab bar visibility controls (see below)
 
 Optional config: `{ threshold?: number; supportIdle?: boolean }`
+
+Hook configuration is scoped to the returned `onScroll` handler. This lets
+multiple mounted screens use different settings without overwriting each
+other. Omitted values inherit the provider configuration; `setThreshold` and
+`setSupportIdle` remain available when you intentionally want to change the
+provider-wide defaults.
+
+```tsx
+const feed = useMotionify({ threshold: 24 });
+const search = useMotionify({ threshold: 12, supportIdle: true });
+
+<FlatList onScroll={feed.onScroll} scrollEventThrottle={16} />;
+<ScrollView onScroll={search.onScroll} scrollEventThrottle={16} />;
+```
 
 #### Tab Bar Controls
 
@@ -482,6 +496,8 @@ Notes:
 ## Performance
 
 - Use `scrollEventThrottle={16}`
+- Direction detection runs in the React Native JS scroll handler; Reanimated
+  SharedValues keep the resulting animations on the UI thread.
 - Keep worklets light; precompute heavy values
 - Prefer interpolation for smoother motion
 - Use `LegendList`, `FlashList` or `FlatList` for long content

--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,13 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/react": "^19.2.18",
+        "@types/react-test-renderer": "^19.1.0",
         "oxlint": "1.78.0",
         "prettier": "3.9.6",
         "react": "^19.1.0",
         "react-native": "0.86.2",
         "react-native-reanimated": "^4.1.3",
+        "react-test-renderer": "^19.2.0",
         "typescript": "^7.0.2",
       },
       "peerDependencies": {
@@ -245,6 +247,8 @@
     "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+
+    "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
 
     "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
 
@@ -560,7 +564,7 @@
 
     "react-devtools-core": ["react-devtools-core@6.1.5", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA=="],
 
-    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+    "react-is": ["react-is@19.2.8", "", {}, "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ=="],
 
     "react-native": ["react-native@0.86.2", "", { "dependencies": { "@react-native/assets-registry": "0.86.2", "@react-native/codegen": "0.86.2", "@react-native/community-cli-plugin": "0.86.2", "@react-native/gradle-plugin": "0.86.2", "@react-native/js-polyfills": "0.86.2", "@react-native/normalize-colors": "0.86.2", "@react-native/virtualized-lists": "0.86.2", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-plugin-syntax-hermes-parser": "0.36.0", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "hermes-compiler": "250829098.0.16", "invariant": "^2.2.4", "memoize-one": "^5.0.0", "metro-runtime": "^0.84.3", "metro-source-map": "^0.84.3", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.27.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "tinyglobby": "^0.2.15", "whatwg-fetch": "^3.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "peerDependencies": { "@react-native/jest-preset": "0.86.2", "@types/react": "^19.1.1", "react": "^19.2.3" }, "optionalPeers": ["@react-native/jest-preset", "@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-zbJXGZpwfZGA79Z9ob6Atvfx4nAQL8yJBa35s58E4Oo+khPykfQP2sTeumkKbjwajFYfVayg8pj7Il9nIfTk7A=="],
 
@@ -571,6 +575,8 @@
     "react-native-worklets": ["react-native-worklets@0.11.3", "", { "dependencies": { "@babel/generator": "^7.27.1", "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.28.6", "@babel/plugin-transform-classes": "^7.28.6", "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6", "@babel/plugin-transform-optional-chaining": "^7.28.6", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.28.5", "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.4" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.83 - 0.86" } }, "sha512-paLRlVFTrrGhkGTi37LHwtaJbrTftA54/zAx1h/ONSBw7XejZn6XUUl1KpM6EOMwsbw7TEGuxJXTAp/wkvuMqQ=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
+
+    "react-test-renderer": ["react-test-renderer@19.2.8", "", { "dependencies": { "react-is": "^19.2.8", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-GHKPaDRaNYU24PHTLG8Bx8VMY9t+qNfxQbt/Yjp7aMWBkKU6766SR0n6TnYu7P5I1MfEuAMUadqiyDHyI4Yy9Q=="],
 
     "regenerate": ["regenerate@1.4.2", "", {}, "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="],
 
@@ -713,6 +719,8 @@
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "@types/react": "^19.2.18",
+    "@types/react-test-renderer": "^19.1.0",
     "oxlint": "1.78.0",
     "prettier": "3.9.6",
     "react": "^19.1.0",
     "react-native": "0.86.2",
     "react-native-reanimated": "^4.1.3",
+    "react-test-renderer": "^19.2.0",
     "typescript": "^7.0.2"
   },
   "files": [

--- a/src/MotionifyBottomTab.tsx
+++ b/src/MotionifyBottomTab.tsx
@@ -19,7 +19,11 @@ import Animated, {
   type SharedValue,
   type WithTimingConfig,
 } from "react-native-reanimated";
-import { useMotionify } from "./MotionifyProvider";
+import {
+  useMotionify,
+  useMotionifyContext,
+  useMotionifySupportIdle,
+} from "./MotionifyProvider";
 import type { InterpolationConfig } from "./types";
 
 /**
@@ -132,7 +136,8 @@ export const MotionifyBottomTab: React.FC<MotionifyBottomTabProps> = ({
   currentId,
   ...restProps
 }) => {
-  const { directionShared, tabBarOverride } = useMotionify({ supportIdle });
+  const { directionShared, tabBarOverride } = useMotionifyContext();
+  useMotionifySupportIdle(supportIdle);
 
   // Track previous route ID to detect route changes
   const prevIdRef = useRef<string | undefined>(currentId);

--- a/src/MotionifyProvider.tsx
+++ b/src/MotionifyProvider.tsx
@@ -19,13 +19,20 @@ import React, {
   type ReactNode,
 } from "react";
 import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
-import { runOnJS, useSharedValue } from "react-native-reanimated";
+import { useSharedValue } from "react-native-reanimated";
 import type {
   Direction,
   MotionifyContextValue,
   MotionifyConfig,
+  ScrollEventHandler,
   TabBarControls,
 } from "./types";
+import {
+  createScrollTracker,
+  resolveMotionifyConfig,
+  updateScrollTracker,
+  type ScrollTracker,
+} from "./scroll";
 
 /**
  * Default configuration values
@@ -37,7 +44,22 @@ const IDLE_TIMEOUT_MS = 200;
 /**
  * React Context for motionify scroll state
  */
-const MotionifyContext = createContext<MotionifyContextValue | null>(null);
+interface ScrollTrackerRef {
+  current: ScrollTracker;
+}
+
+interface MotionifyInternalContextValue extends MotionifyContextValue {
+  handleScroll: (
+    event: Parameters<ScrollEventHandler>[0],
+    trackerRef: ScrollTrackerRef,
+    config: MotionifyConfig,
+  ) => void;
+  registerSupportIdle: () => () => void;
+}
+
+const MotionifyContext = createContext<MotionifyInternalContextValue | null>(
+  null,
+);
 
 /**
  * Props for MotionifyProvider component
@@ -65,8 +87,8 @@ export interface MotionifyProviderProps {
  * MotionifyProvider - Context provider for motionify scroll animations
  *
  * Wraps your app or screen to provide motionify scroll state to all child components.
- * Automatically tracks scroll position and direction using Reanimated worklets
- * for optimal performance.
+ * Tracks scroll position and direction, then publishes SharedValues for
+ * UI-thread animations.
  *
  * @example
  * ```tsx
@@ -111,12 +133,12 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
   const [supportIdle, setSupportIdleState] = useState(initialSupportIdle);
 
   // Refs for tracking scroll state
-  const previousYRef = useRef(0);
-  const scrollStartYRef = useRef(0);
-  const isUserScrollingRef = useRef(false);
+  const providerScrollTrackerRef = useRef(createScrollTracker());
   // `ReturnType<typeof setTimeout>` rather than `NodeJS.Timeout`: React Native
   // has no NodeJS namespace, and its setTimeout returns a number.
   const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const idleGenerationRef = useRef(0);
+  const supportIdleRequestCountRef = useRef(0);
   const thresholdRef = useRef(threshold);
   const supportIdleRef = useRef(supportIdle);
 
@@ -147,33 +169,57 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
    * Reset scroll state to idle after timeout
    */
   const resetToIdle = useCallback(() => {
-    isUserScrollingRef.current = false;
+    idleGenerationRef.current += 1;
     directionShared.value = "idle";
     setDirection("idle");
     setIsScrolling(false);
   }, [directionShared]);
 
+  const clearScrollTimeout = useCallback(() => {
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current);
+      scrollTimeoutRef.current = null;
+    }
+  }, []);
+
   /**
    * Handle scroll timeout for idle state detection
    */
   const resetScrollTimeout = useCallback(() => {
-    if (scrollTimeoutRef.current) {
-      clearTimeout(scrollTimeoutRef.current);
-    }
+    clearScrollTimeout();
 
     scrollTimeoutRef.current = setTimeout(() => {
       resetToIdle();
     }, IDLE_TIMEOUT_MS);
-  }, [resetToIdle]);
+  }, [clearScrollTimeout, resetToIdle]);
 
   /**
-   * Main scroll event handler
-   * Runs on UI thread using Reanimated worklets for optimal performance
+   * Keep component-level idle requests active while at least one requesting
+   * MotionifyView or MotionifyBottomTab is mounted.
    */
-  const onScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      "worklet";
+  const registerSupportIdle = useCallback(() => {
+    supportIdleRequestCountRef.current += 1;
 
+    return () => {
+      supportIdleRequestCountRef.current = Math.max(
+        0,
+        supportIdleRequestCountRef.current - 1,
+      );
+    };
+  }, []);
+
+  /**
+   * Main scroll event handler.
+   *
+   * Direction detection runs on the React Native JS event thread. Shared
+   * values publish its output to UI-thread animations.
+   */
+  const handleScroll = useCallback(
+    (
+      event: NativeSyntheticEvent<NativeScrollEvent>,
+      trackerRef: ScrollTrackerRef,
+      consumerConfig: MotionifyConfig,
+    ) => {
       const currentY = event.nativeEvent.contentOffset.y;
       const contentHeight = event.nativeEvent.contentSize.height;
       const layoutHeight = event.nativeEvent.layoutMeasurement.height;
@@ -185,49 +231,40 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
       // Update shared value (UI thread)
       scrollY.value = clampedY;
 
-      // Calculate delta from previous position
-      const deltaY = clampedY - previousYRef.current;
+      const activeConfig = resolveMotionifyConfig(
+        {
+          threshold: thresholdRef.current,
+          supportIdle:
+            supportIdleRef.current || supportIdleRequestCountRef.current > 0,
+        },
+        consumerConfig,
+      );
 
-      // Initialize scroll start position on first scroll
-      if (!isUserScrollingRef.current) {
-        isUserScrollingRef.current = true;
-        scrollStartYRef.current = clampedY;
+      const trackerUpdate = updateScrollTracker(
+        trackerRef.current,
+        clampedY,
+        activeConfig.threshold,
+        idleGenerationRef.current,
+      );
+      trackerRef.current = trackerUpdate.tracker;
 
-        // Update scrolling state on JS thread
-        runOnJS(updateIsScrolling)(true);
+      if (trackerUpdate.startedScrolling) {
+        updateIsScrolling(true);
       }
 
-      // Detect direction change
-      const currentTotalDelta = clampedY - scrollStartYRef.current;
-      const isDirectionChange =
-        (currentTotalDelta > 0 && deltaY < 0) || // Was scrolling down, now up
-        (currentTotalDelta < 0 && deltaY > 0) || // Was scrolling up, now down
-        (currentTotalDelta === 0 && Math.abs(deltaY) > 0); // Started scrolling
-
-      // Reset scroll start on direction change
-      if (isDirectionChange) {
-        scrollStartYRef.current = clampedY;
+      // Handle idle timeout if enabled for this scroll handler
+      if (activeConfig.supportIdle) {
+        resetScrollTimeout();
+      } else if (scrollTimeoutRef.current) {
+        clearScrollTimeout();
       }
 
-      // Handle idle timeout if enabled
-      if (supportIdleRef.current) {
-        runOnJS(resetScrollTimeout)();
-      }
-
-      // Determine new direction based on total delta from scroll start
-      const totalDelta = clampedY - scrollStartYRef.current;
-      let newDirection: Direction | null = null;
-
-      if (totalDelta > 0) {
-        newDirection = "down";
-      } else if (totalDelta < -thresholdRef.current) {
-        newDirection = "up";
-      }
+      const newDirection = trackerUpdate.direction;
 
       // Update direction if changed
       if (newDirection && newDirection !== directionShared.value) {
         directionShared.value = newDirection;
-        runOnJS(updateDirection)(newDirection);
+        updateDirection(newDirection);
 
         // Reset tab bar override when scroll direction changes
         // This allows scroll-based behavior to resume after programmatic control
@@ -235,14 +272,12 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
           tabBarOverride.value = "none";
         }
       }
-
-      // Update previous position for next frame
-      previousYRef.current = clampedY;
     },
     [
       scrollY,
       directionShared,
       tabBarOverride,
+      clearScrollTimeout,
       resetScrollTimeout,
       updateDirection,
       updateIsScrolling,
@@ -296,15 +331,24 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
   /**
    * Memoized context value
    */
-  const contextValue = useMemo<MotionifyContextValue>(
+  const onScroll = useCallback<ScrollEventHandler>(
+    (event) => {
+      handleScroll(event, providerScrollTrackerRef, {});
+    },
+    [handleScroll],
+  );
+
+  const contextValue = useMemo<MotionifyInternalContextValue>(
     () => ({
       scrollY,
       direction,
       directionShared,
       isScrolling,
       onScroll,
+      handleScroll,
       setThreshold,
       setSupportIdle,
+      registerSupportIdle,
       tabBar: tabBarControls,
       tabBarOverride,
     }),
@@ -314,8 +358,10 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
       directionShared,
       isScrolling,
       onScroll,
+      handleScroll,
       setThreshold,
       setSupportIdle,
+      registerSupportIdle,
       tabBarControls,
       tabBarOverride,
     ],
@@ -323,12 +369,8 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
 
   // Cleanup timeout on unmount
   useEffect(() => {
-    return () => {
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-    };
-  }, []);
+    return clearScrollTimeout;
+  }, [clearScrollTimeout]);
 
   return (
     <MotionifyContext.Provider value={contextValue}>
@@ -358,7 +400,7 @@ export const MotionifyProvider: React.FC<MotionifyProviderProps> = ({
  * }
  * ```
  */
-export const useMotionifyContext = (): MotionifyContextValue => {
+const useMotionifyInternalContext = (): MotionifyInternalContextValue => {
   const context = useContext(MotionifyContext);
 
   if (!context) {
@@ -371,12 +413,32 @@ export const useMotionifyContext = (): MotionifyContextValue => {
   return context;
 };
 
+export const useMotionifyContext = (): MotionifyContextValue =>
+  useMotionifyInternalContext();
+
+/**
+ * Register component-level idle support without allowing one component's
+ * cleanup to disable another mounted component.
+ *
+ * @internal
+ */
+export const useMotionifySupportIdle = (enabled: boolean): void => {
+  const { registerSupportIdle } = useMotionifyInternalContext();
+
+  useEffect(() => {
+    if (enabled) {
+      return registerSupportIdle();
+    }
+  }, [enabled, registerSupportIdle]);
+};
+
 /**
  * Hook for configuring motionify scroll behavior
  *
  * Provides access to scroll state with optional configuration.
  * Use this hook in screens where you want to attach scroll handlers
- * or customize scroll detection behavior.
+ * or customize scroll detection behavior. Configuration is scoped to the
+ * returned scroll handler, so mounted screens do not overwrite each other.
  *
  * @param config - Optional configuration for scroll behavior
  * @returns Motionify scroll context value
@@ -412,33 +474,44 @@ export const useMotionifyContext = (): MotionifyContextValue => {
 export const useMotionify = (
   config: MotionifyConfig = {},
 ): MotionifyContextValue => {
-  const { threshold = DEFAULT_THRESHOLD, supportIdle = DEFAULT_SUPPORT_IDLE } =
-    config;
-  const context = useMotionifyContext();
+  const { threshold, supportIdle } = config;
+  const context = useMotionifyInternalContext();
+  const trackerRef = useRef(createScrollTracker());
+  const consumerConfig = useMemo<MotionifyConfig>(
+    () => ({ threshold, supportIdle }),
+    [supportIdle, threshold],
+  );
+  const { handleScroll } = context;
 
-  // Apply threshold configuration
-  useEffect(() => {
-    if (threshold !== undefined && threshold !== DEFAULT_THRESHOLD) {
-      context.setThreshold(threshold);
+  const configuredOnScroll = useCallback<ScrollEventHandler>(
+    (event) => {
+      handleScroll(event, trackerRef, consumerConfig);
+    },
+    [consumerConfig, handleScroll],
+  );
 
-      // Reset to default on cleanup
-      return () => {
-        context.setThreshold(DEFAULT_THRESHOLD);
-      };
-    }
-  }, [threshold, context]);
-
-  // Apply idle support configuration
-  useEffect(() => {
-    if (supportIdle !== undefined && supportIdle !== DEFAULT_SUPPORT_IDLE) {
-      context.setSupportIdle(supportIdle);
-
-      // Reset to default on cleanup
-      return () => {
-        context.setSupportIdle(DEFAULT_SUPPORT_IDLE);
-      };
-    }
-  }, [supportIdle, context]);
-
-  return context;
+  return useMemo<MotionifyContextValue>(
+    () => ({
+      scrollY: context.scrollY,
+      direction: context.direction,
+      directionShared: context.directionShared,
+      isScrolling: context.isScrolling,
+      onScroll: configuredOnScroll,
+      setThreshold: context.setThreshold,
+      setSupportIdle: context.setSupportIdle,
+      tabBar: context.tabBar,
+      tabBarOverride: context.tabBarOverride,
+    }),
+    [
+      configuredOnScroll,
+      context.direction,
+      context.directionShared,
+      context.isScrolling,
+      context.scrollY,
+      context.setSupportIdle,
+      context.setThreshold,
+      context.tabBar,
+      context.tabBarOverride,
+    ],
+  );
 };

--- a/src/MotionifyView.tsx
+++ b/src/MotionifyView.tsx
@@ -19,7 +19,11 @@ import Animated, {
   type WithTimingConfig,
   type EasingFunction,
 } from "react-native-reanimated";
-import { useMotionify } from "./MotionifyProvider";
+import {
+  useMotionify,
+  useMotionifyContext,
+  useMotionifySupportIdle,
+} from "./MotionifyProvider";
 import type { Direction, InterpolationConfig, TransformStyle } from "./types";
 
 /**
@@ -139,7 +143,8 @@ export const MotionifyView: React.FC<MotionifyViewProps> = ({
   easing,
   ...restProps
 }) => {
-  const { directionShared } = useMotionify({ supportIdle });
+  const { directionShared } = useMotionifyContext();
+  useMotionifySupportIdle(supportIdle);
 
   const animatedStyle = useAnimatedStyle(() => {
     "worklet";

--- a/src/scroll.ts
+++ b/src/scroll.ts
@@ -1,0 +1,102 @@
+import type { Direction, MotionifyConfig } from "./types";
+
+export interface ResolvedMotionifyConfig {
+  threshold: number;
+  supportIdle: boolean;
+}
+
+export interface ScrollTracker {
+  previousY: number;
+  scrollStartY: number;
+  isUserScrolling: boolean;
+  idleGeneration: number;
+}
+
+export interface ScrollTrackerUpdate {
+  tracker: ScrollTracker;
+  direction: Direction | null;
+  startedScrolling: boolean;
+}
+
+/**
+ * Resolve a consumer's scroll configuration without mutating provider state.
+ */
+export const resolveMotionifyConfig = (
+  providerConfig: ResolvedMotionifyConfig,
+  consumerConfig: MotionifyConfig,
+): ResolvedMotionifyConfig => {
+  const consumerThreshold = consumerConfig.threshold;
+
+  return {
+    threshold:
+      consumerThreshold !== undefined && consumerThreshold > 0
+        ? consumerThreshold
+        : providerConfig.threshold,
+    supportIdle: consumerConfig.supportIdle ?? providerConfig.supportIdle,
+  };
+};
+
+/**
+ * Detect direction only after movement exceeds the configured threshold.
+ */
+export const detectScrollDirection = (
+  totalDelta: number,
+  threshold: number,
+): Direction | null => {
+  if (totalDelta > threshold) {
+    return "down";
+  }
+
+  if (totalDelta < -threshold) {
+    return "up";
+  }
+
+  return null;
+};
+
+export const createScrollTracker = (idleGeneration = 0): ScrollTracker => ({
+  previousY: 0,
+  scrollStartY: 0,
+  isUserScrolling: false,
+  idleGeneration,
+});
+
+/**
+ * Advance one consumer's direction detector without sharing scroll offsets
+ * with other mounted consumers.
+ */
+export const updateScrollTracker = (
+  tracker: ScrollTracker,
+  currentY: number,
+  threshold: number,
+  idleGeneration = tracker.idleGeneration,
+): ScrollTrackerUpdate => {
+  const activeTracker =
+    tracker.idleGeneration === idleGeneration
+      ? tracker
+      : createScrollTracker(idleGeneration);
+  const deltaY = currentY - activeTracker.previousY;
+  const startedScrolling = !activeTracker.isUserScrolling;
+  let scrollStartY = startedScrolling ? currentY : activeTracker.scrollStartY;
+
+  const currentTotalDelta = currentY - scrollStartY;
+  const isDirectionChange =
+    (currentTotalDelta > 0 && deltaY < 0) ||
+    (currentTotalDelta < 0 && deltaY > 0) ||
+    (currentTotalDelta === 0 && Math.abs(deltaY) > 0);
+
+  if (isDirectionChange) {
+    scrollStartY = currentY;
+  }
+
+  return {
+    tracker: {
+      previousY: currentY,
+      scrollStartY,
+      isUserScrolling: true,
+      idleGeneration,
+    },
+    direction: detectScrollDirection(currentY - scrollStartY, threshold),
+    startedScrolling,
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface MotionifyConfig {
   /**
    * Minimum scroll delta required to trigger direction change (in pixels)
    * Higher values make direction changes less sensitive
+   * Scoped to the scroll handler returned by this hook invocation
    * @default 8
    */
   threshold?: number;
@@ -39,6 +40,7 @@ export interface MotionifyConfig {
   /**
    * Enable 'idle' direction state when user stops scrolling
    * When enabled, direction becomes 'idle' after 200ms of no scrolling
+   * Scoped to the scroll handler returned by this hook invocation
    * @default false
    */
   supportIdle?: boolean;

--- a/test/provider.test.tsx
+++ b/test/provider.test.tsx
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import React from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import {
+  MotionifyProvider,
+  useMotionify,
+  useMotionifySupportIdle,
+} from "../src/MotionifyProvider";
+import type { MotionifyConfig, MotionifyContextValue } from "../src/types";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const scrollEvent = (y: number) =>
+  ({
+    nativeEvent: {
+      contentOffset: { x: 0, y },
+      contentSize: { height: 1000, width: 100 },
+      layoutMeasurement: { height: 100, width: 100 },
+    },
+  }) as Parameters<MotionifyContextValue["onScroll"]>[0];
+
+describe("useMotionify", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+      renderer = null;
+    }
+  });
+
+  it("keeps mounted consumers independent and their handlers stable", () => {
+    const hooks: Record<string, MotionifyContextValue> = {};
+
+    const Probe = ({
+      id,
+      config,
+    }: {
+      id: string;
+      config?: MotionifyConfig;
+    }) => {
+      hooks[id] = useMotionify(config);
+      return null;
+    };
+
+    act(() => {
+      renderer = create(
+        <MotionifyProvider threshold={30}>
+          <Probe id="fast" config={{ threshold: 8 }} />
+          <Probe id="default" />
+        </MotionifyProvider>,
+      );
+    });
+
+    const fastHandler = hooks.fast.onScroll;
+
+    act(() => hooks.default.onScroll(scrollEvent(100)));
+    act(() => hooks.default.onScroll(scrollEvent(120)));
+    expect(hooks.default.directionShared.value).toBe("idle");
+
+    act(() => hooks.fast.onScroll(scrollEvent(0)));
+    act(() => hooks.fast.onScroll(scrollEvent(9)));
+
+    expect(hooks.fast.directionShared.value).toBe("down");
+    expect(hooks.fast.onScroll).toBe(fastHandler);
+  });
+
+  it("applies provider-wide threshold changes to consumers without overrides", () => {
+    let hook: MotionifyContextValue;
+
+    const Probe = () => {
+      hook = useMotionify();
+      return null;
+    };
+
+    act(() => {
+      renderer = create(
+        <MotionifyProvider threshold={30}>
+          <Probe />
+        </MotionifyProvider>,
+      );
+    });
+    act(() => hook!.setThreshold(8));
+    act(() => hook!.onScroll(scrollEvent(0)));
+    act(() => hook!.onScroll(scrollEvent(9)));
+
+    expect(hook!.directionShared.value).toBe("down");
+  });
+
+  it("does not let component cleanup cancel provider-owned idle", async () => {
+    let hook: MotionifyContextValue;
+
+    const Probe = () => {
+      hook = useMotionify();
+      return null;
+    };
+
+    const IdleRequester = () => {
+      useMotionifySupportIdle(true);
+      return null;
+    };
+
+    const Tree = ({ requestIdle }: { requestIdle: boolean }) => (
+      <MotionifyProvider supportIdle>
+        <Probe />
+        {requestIdle ? <IdleRequester /> : null}
+      </MotionifyProvider>
+    );
+
+    act(() => {
+      renderer = create(<Tree requestIdle />);
+    });
+    act(() => hook!.onScroll(scrollEvent(0)));
+    act(() => hook!.onScroll(scrollEvent(9)));
+    expect(hook!.directionShared.value).toBe("down");
+
+    act(() => renderer?.update(<Tree requestIdle={false} />));
+    await act(async () => {
+      await Bun.sleep(250);
+    });
+
+    expect(hook!.directionShared.value).toBe("idle");
+  });
+
+  it("keeps idle enabled until every component requester unmounts", async () => {
+    let hook: MotionifyContextValue;
+
+    const Probe = () => {
+      hook = useMotionify();
+      return null;
+    };
+
+    const IdleRequester = () => {
+      useMotionifySupportIdle(true);
+      return null;
+    };
+
+    const Tree = ({ requesterCount }: { requesterCount: number }) => (
+      <MotionifyProvider>
+        <Probe />
+        {requesterCount >= 1 ? <IdleRequester key="first" /> : null}
+        {requesterCount >= 2 ? <IdleRequester key="second" /> : null}
+      </MotionifyProvider>
+    );
+
+    act(() => {
+      renderer = create(<Tree requesterCount={2} />);
+    });
+    act(() => renderer?.update(<Tree requesterCount={1} />));
+    act(() => hook!.onScroll(scrollEvent(0)));
+    act(() => hook!.onScroll(scrollEvent(9)));
+    expect(hook!.directionShared.value).toBe("down");
+
+    await act(async () => {
+      await Bun.sleep(250);
+    });
+
+    expect(hook!.directionShared.value).toBe("idle");
+  });
+
+  it("invalidates every consumer tracker when global state becomes idle", async () => {
+    const hooks: Record<string, MotionifyContextValue> = {};
+
+    const Probe = ({ id }: { id: string }) => {
+      hooks[id] = useMotionify({ supportIdle: true });
+      return null;
+    };
+
+    act(() => {
+      renderer = create(
+        <MotionifyProvider>
+          <Probe id="first" />
+          <Probe id="second" />
+        </MotionifyProvider>,
+      );
+    });
+
+    act(() => hooks.first.onScroll(scrollEvent(0)));
+    act(() => hooks.first.onScroll(scrollEvent(9)));
+    act(() => hooks.second.onScroll(scrollEvent(100)));
+    act(() => hooks.second.onScroll(scrollEvent(109)));
+
+    await act(async () => {
+      await Bun.sleep(250);
+    });
+
+    expect(hooks.first.directionShared.value).toBe("idle");
+    expect(hooks.first.isScrolling).toBe(false);
+
+    act(() => hooks.first.onScroll(scrollEvent(10)));
+
+    expect(hooks.first.directionShared.value).toBe("idle");
+    expect(hooks.first.isScrolling).toBe(true);
+  });
+});

--- a/test/scroll.test.ts
+++ b/test/scroll.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  createScrollTracker,
+  detectScrollDirection,
+  resolveMotionifyConfig,
+  updateScrollTracker,
+} from "../src/scroll";
+
+describe("detectScrollDirection", () => {
+  it("requires the threshold before switching down", () => {
+    expect(detectScrollDirection(7, 8)).toBeNull();
+    expect(detectScrollDirection(8, 8)).toBeNull();
+    expect(detectScrollDirection(9, 8)).toBe("down");
+  });
+
+  it("requires the threshold before switching up", () => {
+    expect(detectScrollDirection(-7, 8)).toBeNull();
+    expect(detectScrollDirection(-8, 8)).toBeNull();
+    expect(detectScrollDirection(-9, 8)).toBe("up");
+  });
+});
+
+describe("updateScrollTracker", () => {
+  it("keeps mounted consumers' scroll offsets independent", () => {
+    let first = createScrollTracker();
+    let second = createScrollTracker();
+
+    first = updateScrollTracker(first, 0, 30).tracker;
+    first = updateScrollTracker(first, 20, 30).tracker;
+
+    const secondStart = updateScrollTracker(second, 100, 12);
+    second = secondStart.tracker;
+
+    expect(secondStart.direction).toBeNull();
+    expect(updateScrollTracker(second, 105, 12).direction).toBeNull();
+    expect(updateScrollTracker(first, 40, 30).direction).toBe("down");
+  });
+
+  it("starts a fresh accumulation after becoming idle", () => {
+    let tracker = createScrollTracker();
+    tracker = updateScrollTracker(tracker, 100, 8).tracker;
+    tracker = updateScrollTracker(tracker, 120, 8).tracker;
+
+    const restarted = updateScrollTracker(tracker, 200, 8, 1);
+
+    expect(restarted.startedScrolling).toBe(true);
+    expect(restarted.direction).toBeNull();
+    expect(restarted.tracker.scrollStartY).toBe(200);
+    expect(restarted.tracker.idleGeneration).toBe(1);
+  });
+});
+
+describe("resolveMotionifyConfig", () => {
+  const providerConfig = {
+    threshold: 30,
+    supportIdle: true,
+  };
+
+  it("inherits provider defaults when a consumer has no overrides", () => {
+    expect(resolveMotionifyConfig(providerConfig, {})).toEqual(providerConfig);
+  });
+
+  it("lets each consumer override the provider independently", () => {
+    const first = resolveMotionifyConfig(providerConfig, {
+      threshold: 12,
+      supportIdle: false,
+    });
+    const second = resolveMotionifyConfig(providerConfig, {
+      threshold: 24,
+    });
+
+    expect(first).toEqual({ threshold: 12, supportIdle: false });
+    expect(second).toEqual({ threshold: 24, supportIdle: true });
+    expect(providerConfig).toEqual({ threshold: 30, supportIdle: true });
+  });
+
+  it("allows a consumer to explicitly select the library defaults", () => {
+    expect(
+      resolveMotionifyConfig(providerConfig, {
+        threshold: 8,
+        supportIdle: false,
+      }),
+    ).toEqual({ threshold: 8, supportIdle: false });
+  });
+
+  it("ignores non-positive consumer thresholds like setThreshold", () => {
+    expect(resolveMotionifyConfig(providerConfig, { threshold: 0 })).toEqual(
+      providerConfig,
+    );
+    expect(resolveMotionifyConfig(providerConfig, { threshold: -10 })).toEqual(
+      providerConfig,
+    );
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,4 +1,5 @@
 import { mock } from "bun:test";
+import { useRef } from "react";
 
 /**
  * `react-native-reanimated` pulls in the React Native runtime, which cannot be
@@ -11,5 +12,18 @@ mock.module("react-native-reanimated", () => ({
     CLAMP: "clamp",
     EXTEND: "extend",
     IDENTITY: "identity",
+  },
+  useSharedValue: <T>(initialValue: T) => {
+    const sharedValue = useRef({
+      value: initialValue,
+      get() {
+        return this.value;
+      },
+      set(value: T) {
+        this.value = value;
+      },
+    });
+
+    return sharedValue.current;
   },
 }));


### PR DESCRIPTION
Make scroll configuration predictable across multiple mounted consumers and apply direction thresholds consistently.

## What changed

- apply the configured threshold symmetrically to upward and downward scrolling
- give each `useMotionify` invocation an independent scroll tracker and scoped configuration
- invalidate every consumer tracker after global idle without cross-screen stale deltas
- preserve provider-wide setters and reference-count component-level idle requests
- document the JS-thread detector and UI-thread animation boundary
- add pure and provider-level regression coverage

Fixes #4
Fixes #5

## Testing

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test` — 45 tests passed
- `bun run build`
- `npm pack --dry-run --json`
- `bun install --frozen-lockfile` in `example`
- `bunx expo install --check` in `example`
- `bunx expo-doctor@1.20.1` in `example` — 20/20 checks passed

## Risk

Direction changes now wait until movement strictly exceeds the threshold in either direction. The change is covered by per-consumer, idle-lifecycle, and integration regression tests.
